### PR TITLE
Add feature to read sqlite3 databases without closing Google Chrome

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -36,7 +36,7 @@ This script parses the files in the Chrome/Chromium/Brave data folder, runs vari
    against the data, and then outputs the results in a spreadsheet. '''.format(pyhindsight.__version__)
 
     epi = '''
-Example:  C:\>hindsight.py -i "C:\\Users\Ryan\AppData\Local\Google\Chrome\\User Data\Default" -o test_case
+Example:  C:\\hindsight.py -i "C:\\Users\Ryan\AppData\Local\Google\Chrome\\User Data\Default" -o test_case
 
 The Chrome data folder default locations are:
         WinXP: <userdir>\Local Settings\Application Data\Google\Chrome
@@ -76,6 +76,10 @@ The Chrome data folder default locations are:
                              'Chrome data is from.')
     parser.add_argument('-c', '--cache', help='Path to the cache directory; only needed if the directory is outside '
                                               'the given "input" directory. Mac systems are setup this way by default.')
+    parser.add_argument('--nocopy', '--no_copy', help='Don\'t copy files before opening them; this might run faster, '
+                                                      'but some locked files may be inaccessible', action='store_true')
+    parser.add_argument('--temp_dir', default='hindsight-temp',
+                        help='If files are copied before being opened, use this directory as the copy destination')
 
     args = parser.parse_args()
 
@@ -174,6 +178,8 @@ def main():
     analysis_session.selected_output_format = args.format
     analysis_session.browser_type = args.browser_type
     analysis_session.timezone = args.timezone
+    analysis_session.no_copy = args.nocopy
+    analysis_session.temp_dir = args.temp_dir
 
     if args.log == 'hindsight.log':
         args.log = os.path.join(real_path, args.log)

--- a/hindsight.py
+++ b/hindsight.py
@@ -121,7 +121,8 @@ def main():
         string_buffer.seek(0)
 
         # Write the StringIO object to a file on disk named what the user specified
-        with open(f'{os.path.join(real_path, analysis_session.output_name)}.{analysis_session.selected_output_format}', 'wb') as file_output:
+        with open(f'{os.path.join(real_path, analysis_session.output_name)}.{analysis_session.selected_output_format}',
+                  'wb') as file_output:
             shutil.copyfileobj(string_buffer, file_output)
 
     def write_sqlite(analysis_session):

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -213,8 +213,8 @@ class HindsightEncoder(json.JSONEncoder):
 class AnalysisSession(object):
     def __init__(
             self, input_path=None, profile_paths=None, cache_path=None, browser_type=None, available_input_types=None,
-            version=None, display_version=None, output_name=None, log_path=None, timezone=None,
-            available_output_formats=None, selected_output_format=None, available_decrypts=None,
+            version=None, display_version=None, output_name=None, log_path=None, no_copy=None, temp_dir=None,
+            timezone=None, available_output_formats=None, selected_output_format=None, available_decrypts=None,
             selected_decrypts=None, parsed_artifacts=None, artifacts_display=None, artifacts_counts=None,
             parsed_storage=None, plugin_descriptions=None, selected_plugins=None, plugin_results=None,
             hindsight_version=None, preferences=None):
@@ -227,6 +227,8 @@ class AnalysisSession(object):
         self.display_version = display_version
         self.output_name = output_name
         self.log_path = log_path
+        self.no_copy = no_copy
+        self.temp_dir = temp_dir
         self.timezone = timezone
         self.available_output_formats = available_output_formats
         self.selected_output_format = selected_output_format
@@ -444,7 +446,8 @@ class AnalysisSession(object):
 
             if self.browser_type == "Chrome":
                 browser_analysis = Chrome(found_profile_path, available_decrypts=self.available_decrypts,
-                                          cache_path=self.cache_path, timezone=self.timezone)
+                                          cache_path=self.cache_path, timezone=self.timezone,
+                                          no_copy=self.no_copy, temp_dir=self.temp_dir)
                 browser_analysis.process()
                 self.parsed_artifacts.extend(browser_analysis.parsed_artifacts)
                 self.parsed_storage.extend(browser_analysis.parsed_storage)

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -338,6 +338,9 @@ class Chrome(WebBrowser):
 
         log.info("Download items from {}:".format(database))
 
+        # Create temp copy of database
+        utils.create_temp_db(path, database)
+
         # Get directory of temporay database
         path = utils.get_temp_db_directory()
 

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2052,6 +2052,10 @@ class Chrome(WebBrowser):
 
         self.parsed_artifacts.sort()
 
+        # Clean temp directory after processsing profile
+        shutil.rmtree(utils.get_temp_db_directory())
+
+
     class URLItem(WebBrowser.URLItem):
         def __init__(self, profile, url_id, url, title, visit_time, last_visit_time, visit_count, typed_count, from_visit,
                      transition, hidden, favicon_id, indexed=None, visit_duration=None, visit_source=None,

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -239,6 +239,12 @@ class Chrome(WebBrowser):
 
         log.info("History items from {}:".format(history_file))
 
+        # Create temp copy of database
+        utils.create_temp_db(path, history_file)
+
+        # Get directory of temporay database
+        path = utils.get_temp_db_directory()
+
         # TODO: visit_source table?  don't have good sample data
         # TODO: visits where visit_count = 0; means it should be in Archived History but could be helpful to have if
         # that file is missing.  Changing the first JOIN to a LEFT JOIN adds these in.
@@ -276,7 +282,7 @@ class Chrome(WebBrowser):
         if compatible_version is not 0:
             log.info(" - Using SQL query for History items for Chrome v{}".format(compatible_version))
             try:
-                # Connect to 'History' sqlite db
+                # Connect to temp 'History' sqlite db
                 history_path = os.path.join(path, history_file)
                 db_file = sqlite3.connect(history_path)
                 log.info(" - Reading from file '{}'".format(history_path))
@@ -332,6 +338,9 @@ class Chrome(WebBrowser):
 
         log.info("Download items from {}:".format(database))
 
+        # Get directory of temporay database
+        path = utils.get_temp_db_directory()
+
         # Queries for different versions
         query = {30: '''SELECT downloads.id, downloads_url_chains.url, downloads.received_bytes, downloads.total_bytes,
                             downloads.state, downloads.target_path, downloads.start_time, downloads.end_time,
@@ -359,7 +368,7 @@ class Chrome(WebBrowser):
         if compatible_version is not 0:
             log.info(" - Using SQL query for Download items for Chrome v{}".format(compatible_version))
             try:
-                # Connect to 'History' sqlite db
+                # Connect to temp 'History' sqlite db
                 history_path = os.path.join(path, database)
                 db_file = sqlite3.connect(history_path)
                 log.info(" - Reading from file '{}'".format(history_path))
@@ -488,6 +497,12 @@ class Chrome(WebBrowser):
 
         log.info("Cookie items from {}:".format(database))
 
+        # Create temp copy of database
+        utils.create_temp_db(path, database)
+
+        # Get directory of temporay database
+        path = utils.get_temp_db_directory()
+
         # Queries for different versions
         query = {66: '''SELECT cookies.host_key, cookies.path, cookies.name, cookies.value, cookies.creation_utc,
                             cookies.last_access_utc, cookies.expires_utc, cookies.is_secure AS secure, 
@@ -518,7 +533,7 @@ class Chrome(WebBrowser):
         if compatible_version is not 0:
             log.info(" - Using SQL query for Cookie items for Chrome v{}".format(compatible_version))
             try:
-                # Connect to 'Cookies' sqlite db
+                # Connect to temp 'Cookies' sqlite db
                 db_path = os.path.join(path, database)
                 db_file = sqlite3.connect(db_path)
                 log.info(" - Reading from file '{}'".format(db_path))
@@ -585,6 +600,12 @@ class Chrome(WebBrowser):
 
         log.info(f'Login items from {database}:')
 
+        # Create temp copy of database
+        utils.create_temp_db(path, database)
+
+        # Get directory of temporay database
+        path = utils.get_temp_db_directory()
+
         # Queries for "logins" table for different versions
         query = {78:  '''SELECT origin_url, action_url, username_element, username_value, password_element,
                             password_value, date_created, date_last_used, blacklisted_by_user, 
@@ -602,7 +623,7 @@ class Chrome(WebBrowser):
         if compatible_version is not 0:
             log.info(f' - Using SQL query for Login items for Chrome v{compatible_version}')
             try:
-                # Connect to 'Login Data' sqlite db
+                # Connect to temp 'Login Data' sqlite db
                 db_path = os.path.join(path, database)
                 db_file = sqlite3.connect(db_path)
                 log.info(f' - Reading from file "{db_path}"')
@@ -679,7 +700,7 @@ class Chrome(WebBrowser):
             if compatible_version is not 0:
                 log.info(f' - Using SQL query for Login Stat items for Chrome v{compatible_version}')
                 try:
-                    # Connect to 'Login Data' sqlite db
+                    # Connect to temp 'Login Data' sqlite db
                     db_path = os.path.join(path, database)
                     db_file = sqlite3.connect(db_path)
                     log.info(f' - Reading from file "{db_path}"')
@@ -717,6 +738,12 @@ class Chrome(WebBrowser):
 
         log.info("Autofill items from {}:".format(database))
 
+        # Create temp copy of database
+        utils.create_temp_db(path, database)
+
+        # Get directory of temporay database
+        path = utils.get_temp_db_directory()
+
         # Queries for different versions
         query = {35: '''SELECT autofill.date_created, autofill.date_last_used, autofill.name, autofill.value,
                         autofill.count FROM autofill''',
@@ -731,7 +758,7 @@ class Chrome(WebBrowser):
         if compatible_version is not 0:
             log.info(" - Using SQL query for Autofill items for Chrome v{}".format(compatible_version))
             try:
-                # Connect to 'Web Data' SQLite db
+                # Connect to temp 'Web Data' SQLite db
                 db_path = os.path.join(path, database)
                 db_file = sqlite3.connect(db_path)
                 log.info(" - Reading from file '{}'".format(db_path))

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -864,7 +864,15 @@ class Chrome(WebBrowser):
                 ls_file_path = os.path.join(ls_path, ls_file)
                 ls_created = os.stat(ls_file_path).st_ctime
 
-                # Connect to Local Storage file sqlite db
+                # Create temp copy of database
+                utils.create_temp_db(ls_path, ls_file)
+
+                # Get directory of temporay database
+                ls_path = utils.get_temp_db_directory()
+
+                # Connect to temp Local Storage file sqlite db
+                ls_file_path = os.path.join(ls_path, ls_file)
+
                 try:
                     db_file = sqlite3.connect(ls_file_path)
                 except Exception as e:
@@ -1583,7 +1591,13 @@ class Chrome(WebBrowser):
         cache_path = os.path.join(base_path, 'Cache')
         log.info(f'Application Cache items from {path}:')
 
-        # Connect to 'Index' sqlite db
+        # Create temp copy of database
+        utils.create_temp_db(base_path, 'Index')
+
+        # Get directory of temporay database
+        base_path = utils.get_temp_db_directory()
+
+        # Connect to temp 'Index' sqlite db
         db_path = os.path.join(base_path, 'Index')
         try:
             index_db = sqlite3.connect(db_path)

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -2,6 +2,7 @@ import sqlite3
 import os
 import sys
 import logging
+from pyhindsight import utils
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +64,15 @@ class WebBrowser(object):
         if database not in list(self.structure.keys()):
             self.structure[database] = {}
 
-            # Connect to SQLite db
-            database_path = os.path.join(path, database)
+            # Create temp copy of database
+            utils.create_temp_db(path, database)
+
+            # Get directory of temporay database
+            temp_db_directory = utils.get_temp_db_directory()
+
+            # Connect to temp SQLite db
+            database_path = os.path.join(temp_db_directory, database)
+
             try:
                 db = sqlite3.connect(database_path)
                 cursor = db.cursor()

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -64,15 +64,8 @@ class WebBrowser(object):
         if database not in list(self.structure.keys()):
             self.structure[database] = {}
 
-            # Create temp copy of database
-            utils.create_temp_db(path, database)
-
-            # Get directory of temporay database
-            temp_db_directory = utils.get_temp_db_directory()
-
-            # Connect to temp SQLite db
-            database_path = os.path.join(temp_db_directory, database)
-
+            # Connect to SQLite db
+            database_path = os.path.join(path, database)
             try:
                 db = sqlite3.connect(database_path)
                 cursor = db.cursor()

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -255,6 +255,21 @@ class WebBrowser(object):
             self.value = value
             self.interpretation = interpretation
 
+    class MediaItem(HistoryItem):
+        def __init__(
+                self, profile, url, title, last_updated, position=None, media_duration=None,
+                source_title=None, watch_time=None):
+            super(WebBrowser.MediaItem, self).__init__(
+                'media', timestamp=last_updated, profile=profile, url=url, name=title)
+            self.profile = profile
+            self.url = url
+            self.title = title
+            self.last_updated = last_updated
+            self.position = position
+            self.media_duration = media_duration
+            self.source_title = source_title
+            self.watch_time = watch_time
+
     class StorageItem(object):
         def __init__(self, item_type, profile, origin, key, value=None, last_modified=None, interpretation=None):
             self.row_type = item_type

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -11,7 +11,7 @@ class WebBrowser(object):
     def __init__(
             self, profile_path, browser_name, cache_path=None, version=None, display_version=None,
             timezone=None, structure=None, parsed_artifacts=None, parsed_storage=None, artifacts_counts=None,
-            artifacts_display=None, preferences=None):
+            artifacts_display=None, preferences=None, no_copy=None, temp_dir=None):
         self.profile_path = profile_path
         self.browser_name = browser_name
         self.cache_path = cache_path
@@ -24,6 +24,8 @@ class WebBrowser(object):
         self.artifacts_counts = artifacts_counts
         self.artifacts_display = artifacts_display
         self.preferences = preferences
+        self.no_copy = no_copy
+        self.temp_dir = temp_dir
 
         if self.version is None:
             self.version = []
@@ -65,7 +67,7 @@ class WebBrowser(object):
             self.structure[database] = {}
 
             # Copy and connect to copy of SQLite DB
-            conn = utils.copy_and_connect_to_sqlite_db(path, database)
+            conn = utils.open_sqlite_db(self, path, database)
             if not conn:
                 self.artifacts_counts[database] = 'Failed'
                 return

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -4,9 +4,14 @@ import logging
 import pytz
 import struct
 from pyhindsight import __version__
+import os
+import shutil
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+# Temp directory name
+temp_directory_name="temp"
 
 def format_plugin_output(name, version, items):
     width = 80
@@ -162,6 +167,15 @@ def read_int32(input_bytes, ptr):
 def read_int64(input_bytes, ptr):
     value = struct.unpack('<Q', input_bytes[ptr:ptr + 8])[0]
     return value, ptr + 8
+
+
+def create_temp_db(path, database):
+
+    # Create 'temp' directory if doesn't exists
+    Path(temp_directory_name).mkdir(parents=True, exist_ok=True)
+
+    # Copy database to temp directory
+    shutil.copyfile(os.path.join(path, database), os.path.join(temp_directory_name, database))
 
 
 banner = '''

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -178,6 +178,9 @@ def create_temp_db(path, database):
     shutil.copyfile(os.path.join(path, database), os.path.join(temp_directory_name, database))
 
 
+def get_temp_db_directory():
+    return temp_directory_name
+
 banner = '''
 ################################################################################
 

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -123,7 +123,13 @@ def get_ldb_pairs(ldb_path, prefix=''):
         return []
 
     cleaned_pairs = []
-    pairs = list(db.iterator())
+
+    try:
+        pairs = list(db.iterator())
+    except Exception as e:
+        log.warning(f' - Couldn\'t read {ldb_path} LevelDB data; {e}')
+        return []
+
     for pair in pairs:
         # Each leveldb pair should be a tuple of length 2 (key & value); if not, log it and skip it.
         if not isinstance(pair, tuple) or len(pair) is not 2:

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -19,23 +19,27 @@ def dict_factory(cursor, row):
     return d
 
 
-def copy_and_connect_to_sqlite_db(database_path, database_name, temp_directory_name='temp'):
+def open_sqlite_db(chrome, database_path, database_name):
     log.info(f' - Reading from {database_name} in {database_path}')
 
-    try:
-        # Create 'temp' directory if doesn't exists
-        Path(temp_directory_name).mkdir(parents=True, exist_ok=True)
+    if chrome.no_copy:
+        db_path_to_open = os.path.join(database_path, database_name)
 
-        # Copy database to temp directory
-        copied_db_path = os.path.join(temp_directory_name, database_name)
-        shutil.copyfile(os.path.join(database_path, database_name), copied_db_path)
-    except Exception as e:
-        log.error(f' - Error copying {database_name}: {e}')
-        return None
+    else:
+        try:
+            # Create 'temp' directory if doesn't exists
+            Path(chrome.temp_dir).mkdir(parents=True, exist_ok=True)
+
+            # Copy database to temp directory
+            db_path_to_open = os.path.join(chrome.temp_dir, database_name)
+            shutil.copyfile(os.path.join(database_path, database_name), db_path_to_open)
+        except Exception as e:
+            log.error(f' - Error copying {database_name}: {e}')
+            return None
 
     try:
         # Connect to copied database
-        db_conn = sqlite3.connect(copied_db_path)
+        db_conn = sqlite3.connect(db_path_to_open)
 
         # Use a dictionary cursor
         db_conn.row_factory = dict_factory


### PR DESCRIPTION
#28
This pull request will add the following features:
 - Creating a temp local copy of the sqlite3 database and connecting them
 - Deleting the temp local directory after processing profiles
 - Add error handling for plyvel.Corruption Error and logging it

Please let me know if any changes are required.