### PR TITLE
Change XLSX output to write to CWD

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -125,8 +125,7 @@ def main():
         string_buffer.seek(0)
 
         # Write the StringIO object to a file on disk named what the user specified
-        with open(f'{os.path.join(real_path, analysis_session.output_name)}.{analysis_session.selected_output_format}',
-                  'wb') as file_output:
+        with open(f'{analysis_session.output_name}.{analysis_session.selected_output_format}', 'wb') as file_output:
             shutil.copyfileobj(string_buffer, file_output)
 
     def write_sqlite(analysis_session):


### PR DESCRIPTION
Fixes #53. 

Initially, Hindsight would try to write everything to the directory where hindsight.py was, but as other output formats were added, the output paths became inconsistent. Changing the XLSX default output directory makes everything the same now; #51 moved the log to the CWD, and I think everything going to CWD makes sense, especially in light of the packaging and venv concerns raised by @ryneeverett and @aarontp. 