### PR TITLE
Leveldb rework

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -47,8 +47,11 @@ class HindsightEncoder(json.JSONEncoder):
 
             item[key] = value
 
-        item['datetime'] = item['timestamp']
-        del(item['timestamp'])
+        if item.get('timestamp'):
+            item['datetime'] = item['timestamp']
+            del(item['timestamp'])
+        else:
+            item['datetime'] = '1970-01-01T00:00:00.000000+00:00'
 
         return item
 
@@ -835,25 +838,31 @@ class AnalysisSession(object):
 
         s = workbook.add_worksheet('Storage')
         # Title bar
-        s.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
+        s.merge_range('A1:J1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
 
         # Write column headers
         s.write(1, 0, 'Type', header_format)
         s.write(1, 1, 'Origin', header_format)
         s.write(1, 2, 'Key', header_format)
         s.write(1, 3, 'Value', header_format)
-        s.write(1, 4, 'Modification Time ({})'.format(self.timezone), header_format)
-        s.write(1, 5, 'Interpretation', header_format)
-        s.write(1, 6, 'Profile', header_format)
- 
+        s.write(1, 4, 'Sequence', header_format)
+        s.write(1, 5, 'State', header_format)
+        s.write(1, 6, 'Modification Time ({})'.format(self.timezone), header_format)
+        s.write(1, 7, 'Interpretation', header_format)
+        s.write(1, 8, 'Profile', header_format)
+        s.write(1, 9, 'Source Path', header_format)
+
         # Set column widths
         s.set_column('A:A', 16)  # Type
         s.set_column('B:B', 30)  # Origin
         s.set_column('C:C', 35)  # Key
         s.set_column('D:D', 60)  # Value
-        s.set_column('E:E', 16)  # Mod Time
-        s.set_column('F:F', 50)  # Interpretation
-        s.set_column('G:G', 50)  # Profile
+        s.set_column('E:E', 8)  # Seq
+        s.set_column('F:F', 8)  # State
+        s.set_column('G:G', 16)  # Mod Time
+        s.set_column('H:H', 50)  # Interpretation
+        s.set_column('I:I', 50)  # Profile
+        s.set_column('J:J', 50)  # Source Path
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -873,9 +882,12 @@ class AnalysisSession(object):
                     s.write_string(row_number, 1, item.origin, black_url_format)
                     s.write_string(row_number, 2, item.key, black_field_format)
                     s.write_string(row_number, 3, item.value, black_value_format)
-                    s.write(row_number, 4, friendly_date(item.last_modified), black_date_format)
-                    s.write(row_number, 5, item.interpretation, black_value_format)
-                    s.write(row_number, 6, item.profile, black_value_format)
+                    s.write_number(row_number, 4, item.seq, black_value_format)
+                    s.write_string(row_number, 5, item.state, black_value_format)
+                    s.write(row_number, 6, friendly_date(item.last_modified), black_date_format)
+                    s.write(row_number, 7, item.interpretation, black_value_format)
+                    s.write(row_number, 8, item.profile, black_value_format)
+                    s.write(row_number, 9, item.source_path, black_value_format)
 
             except Exception as e:
                 log.error(f'Failed to write row to XLSX: {e}')
@@ -884,7 +896,7 @@ class AnalysisSession(object):
 
         # Formatting
         s.freeze_panes(2, 0)  # Freeze top row
-        s.autofilter(1, 0, row_number, 6)  # Add autofilter
+        s.autofilter(1, 0, row_number, 9)  # Add autofilter
 
         for item in self.__dict__:
             try:
@@ -965,8 +977,8 @@ class AnalysisSession(object):
                 'opened INT, etag TEXT, last_modified TEXT, server_name TEXT, data_location TEXT, http_headers TEXT)')
 
             c.execute(
-                'CREATE TABLE storage(type TEXT, origin TEXT, key TEXT, value TEXT, modification_time TEXT, '
-                'interpretation TEXT, profile TEXT)')
+                'CREATE TABLE storage(type TEXT, origin TEXT, key TEXT, value TEXT, seq INT, state TEXT, '
+                'modification_time TEXT, interpretation TEXT, profile TEXT, source_path TEXT)')
 
             c.execute(
                 'CREATE TABLE installed_extensions(name TEXT, description TEXT, version TEXT, app_id TEXT, '
@@ -1066,10 +1078,11 @@ class AnalysisSession(object):
             for item in self.parsed_storage:
                 if item.row_type.startswith('local'):
                     c.execute(
-                        'INSERT INTO storage (type, origin, key, value, modification_time, interpretation, profile) '
-                        'VALUES (?, ?, ?, ?, ?, ?, ?)',
-                        (item.row_type, item.origin, item.key, item.value, item.last_modified, item.interpretation,
-                         item.profile))
+                        'INSERT INTO storage (type, origin, key, value, seq, state, modification_time, '
+                        'interpretation, profile, source_path) '
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        (item.row_type, item.origin, item.key, item.value, item.seq, item.state,
+                         item.last_modified, item.interpretation, item.profile, item.source_path))
 
                 if item.row_type.startswith('file system'):
                     c.execute(
@@ -1090,4 +1103,8 @@ class AnalysisSession(object):
             for parsed_artifact in self.parsed_artifacts:
                 parsed_artifact_json = json.dumps(parsed_artifact, cls=HindsightEncoder)
                 jsonl.write(parsed_artifact_json)
+                jsonl.write('\n')
+            for parsed_storage in self.parsed_storage:
+                parsed_storage_json = json.dumps(parsed_storage, cls=HindsightEncoder)
+                jsonl.write(parsed_storage_json)
                 jsonl.write('\n')

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -992,7 +992,8 @@ class AnalysisSession(object):
 
             c.execute(
                 'CREATE TABLE storage(type TEXT, origin TEXT, key TEXT, value TEXT, seq INT, state TEXT, '
-                'modification_time TEXT, interpretation TEXT, profile TEXT, source_path TEXT)')
+                'modification_time TEXT, interpretation TEXT, profile TEXT, source_path TEXT, '
+                'file_exists BOOL, file_size INT, magic_results TEXT)')
 
             c.execute(
                 'CREATE TABLE installed_extensions(name TEXT, description TEXT, version TEXT, app_id TEXT, '
@@ -1092,18 +1093,21 @@ class AnalysisSession(object):
             for item in self.parsed_storage:
                 if item.row_type.startswith('local'):
                     c.execute(
-                        'INSERT INTO storage (type, origin, key, value, seq, state, modification_time, '
-                        'interpretation, profile, source_path) '
+                        'INSERT INTO storage (type, origin, key, value, modification_time, '
+                        'interpretation, profile, source_path, seq, state) '
                         'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-                        (item.row_type, item.origin, item.key, item.value, item.seq, item.state,
-                         item.last_modified, item.interpretation, item.profile, item.source_path))
+                        (item.row_type, item.origin, item.key, item.value, item.last_modified,
+                         item.interpretation, item.profile, item.source_path, item.seq, item.state))
 
                 if item.row_type.startswith('file system'):
                     c.execute(
-                        'INSERT INTO storage (type, origin, key, value, modification_time, interpretation, profile) '
-                        'VALUES (?, ?, ?, ?, ?, ?, ?)',
-                        (item.row_type, item.origin, item.key, item.value, item.last_modified, item.interpretation,
-                         item.profile))
+                        'INSERT INTO storage (type, origin, key, value, modification_time, '
+                        'interpretation, profile, source_path, seq, state, file_exists, file_size, '
+                        'magic_results) '
+                        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                        (item.row_type, item.origin, item.key, item.value, item.last_modified,
+                         item.interpretation, item.profile, item.source_path, item.seq, item.state,
+                         item.file_exists, item.file_size, item.magic_results))
 
             if self.__dict__.get('installed_extensions'):
                 for extension in self.installed_extensions['data']:

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -845,24 +845,24 @@ class AnalysisSession(object):
         s.write(1, 1, 'Origin', header_format)
         s.write(1, 2, 'Key', header_format)
         s.write(1, 3, 'Value', header_format)
-        s.write(1, 4, 'Sequence', header_format)
-        s.write(1, 5, 'State', header_format)
-        s.write(1, 6, 'Modification Time ({})'.format(self.timezone), header_format)
-        s.write(1, 7, 'Interpretation', header_format)
-        s.write(1, 8, 'Profile', header_format)
-        s.write(1, 9, 'Source Path', header_format)
+        s.write(1, 4, 'Modification Time ({})'.format(self.timezone), header_format)
+        s.write(1, 5, 'Interpretation', header_format)
+        s.write(1, 6, 'Profile', header_format)
+        s.write(1, 7, 'Source Path', header_format)
+        s.write(1, 8, 'Sequence', header_format)
+        s.write(1, 9, 'State', header_format)
 
         # Set column widths
         s.set_column('A:A', 16)  # Type
         s.set_column('B:B', 30)  # Origin
         s.set_column('C:C', 35)  # Key
         s.set_column('D:D', 60)  # Value
-        s.set_column('E:E', 8)  # Seq
-        s.set_column('F:F', 8)  # State
-        s.set_column('G:G', 16)  # Mod Time
-        s.set_column('H:H', 50)  # Interpretation
-        s.set_column('I:I', 50)  # Profile
-        s.set_column('J:J', 50)  # Source Path
+        s.set_column('E:E', 16)  # Mod Time
+        s.set_column('F:F', 50)  # Interpretation
+        s.set_column('G:G', 50)  # Profile
+        s.set_column('H:H', 50)  # Source Path
+        s.set_column('I:I', 8)  # Seq
+        s.set_column('J:J', 8)  # State
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -876,18 +876,21 @@ class AnalysisSession(object):
                     s.write(row_number, 4, friendly_date(item.last_modified), black_date_format)
                     s.write(row_number, 5, item.interpretation, black_value_format)
                     s.write(row_number, 6, item.profile, black_value_format)
+                    s.write(row_number, 7, item.source_path, black_value_format)
+                    s.write_number(row_number, 8, item.seq, black_value_format)
+                    s.write_string(row_number, 9, item.state, black_value_format)
 
                 elif item.row_type.startswith("local storage"):
                     s.write_string(row_number, 0, item.row_type, black_type_format)
                     s.write_string(row_number, 1, item.origin, black_url_format)
                     s.write_string(row_number, 2, item.key, black_field_format)
                     s.write_string(row_number, 3, item.value, black_value_format)
-                    s.write_number(row_number, 4, item.seq, black_value_format)
-                    s.write_string(row_number, 5, item.state, black_value_format)
-                    s.write(row_number, 6, friendly_date(item.last_modified), black_date_format)
-                    s.write(row_number, 7, item.interpretation, black_value_format)
-                    s.write(row_number, 8, item.profile, black_value_format)
-                    s.write(row_number, 9, item.source_path, black_value_format)
+                    s.write(row_number, 4, friendly_date(item.last_modified), black_date_format)
+                    s.write(row_number, 5, item.interpretation, black_value_format)
+                    s.write(row_number, 6, item.profile, black_value_format)
+                    s.write(row_number, 7, item.source_path, black_value_format)
+                    s.write_number(row_number, 8, item.seq, black_value_format)
+                    s.write_string(row_number, 9, item.state, black_value_format)
 
             except Exception as e:
                 log.error(f'Failed to write row to XLSX: {e}')

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -838,7 +838,9 @@ class AnalysisSession(object):
 
         s = workbook.add_worksheet('Storage')
         # Title bar
-        s.merge_range('A1:J1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
+        s.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
+        s.merge_range('H1:J1', 'Backing Database Specific', center_header_format)
+        s.merge_range('K1:M1', 'FileSystem Specific', center_header_format)
 
         # Write column headers
         s.write(1, 0, 'Type', header_format)
@@ -851,6 +853,9 @@ class AnalysisSession(object):
         s.write(1, 7, 'Source Path', header_format)
         s.write(1, 8, 'Sequence', header_format)
         s.write(1, 9, 'State', header_format)
+        s.write(1, 10, 'File Exists?', header_format)
+        s.write(1, 11, 'File Size (bytes)', header_format)
+        s.write(1, 12, 'File Type (Confidence %)', header_format)
 
         # Set column widths
         s.set_column('A:A', 16)  # Type
@@ -863,6 +868,9 @@ class AnalysisSession(object):
         s.set_column('H:H', 50)  # Source Path
         s.set_column('I:I', 8)  # Seq
         s.set_column('J:J', 8)  # State
+        s.set_column('K:K', 8)  # Exists
+        s.set_column('L:L', 16)  # Size
+        s.set_column('M:M', 25)  # Type
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
@@ -879,6 +887,9 @@ class AnalysisSession(object):
                     s.write(row_number, 7, item.source_path, black_value_format)
                     s.write_number(row_number, 8, item.seq, black_value_format)
                     s.write_string(row_number, 9, item.state, black_value_format)
+                    s.write(row_number, 10, item.file_exists, black_value_format)
+                    s.write(row_number, 11, item.file_size, black_value_format)
+                    s.write(row_number, 12, item.magic_results, black_value_format)
 
                 elif item.row_type.startswith("local storage"):
                     s.write_string(row_number, 0, item.row_type, black_type_format)
@@ -899,7 +910,7 @@ class AnalysisSession(object):
 
         # Formatting
         s.freeze_panes(2, 0)  # Freeze top row
-        s.autofilter(1, 0, row_number, 9)  # Add autofilter
+        s.autofilter(1, 0, row_number, 12)  # Add autofilter
 
         for item in self.__dict__:
             try:

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -2145,11 +2145,15 @@ class Chrome(WebBrowser):
         self.cached_key = None
 
         self.parsed_artifacts.sort()
+        self.parsed_storage.sort()
 
         # Clean temp directory after processing profile
         if not self.no_copy:
             log.info(f'Deleting temporary directory {self.temp_dir}')
-            shutil.rmtree(self.temp_dir)
+            try:
+                shutil.rmtree(self.temp_dir)
+            except Exception as e:
+                log.error(f'Exception deleting temporary directory: {e}')
 
     class URLItem(WebBrowser.URLItem):
         def __init__(self, profile, url_id, url, title, visit_time, last_visit_time, visit_count, typed_count, from_visit,

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -273,12 +273,16 @@ class WebBrowser(object):
             self.has_audio = has_audio
 
     class StorageItem(object):
-        def __init__(self, item_type, profile, origin, key, value=None, last_modified=None, interpretation=None):
+        def __init__(self, item_type, profile, origin, key, value=None, seq=None, state=None, source_path=None,
+                     last_modified=None, interpretation=None):
             self.row_type = item_type
             self.profile = profile
             self.origin = origin
             self.key = key
             self.value = value
+            self.seq = seq
+            self.state = state
+            self.source_path = source_path
             self.last_modified = last_modified
             self.interpretation = interpretation
 
@@ -289,7 +293,7 @@ class WebBrowser(object):
             return iter(self.__dict__)
 
     class LocalStorageItem(StorageItem):
-        def __init__(self, profile, origin, key, value, last_modified=None):
+        def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None):
             """
 
             :param profile: The path to the browser profile this item is part of.
@@ -297,6 +301,9 @@ class WebBrowser(object):
             :param key: The key of the LocalStorage item.
             :param value: The value of the LocalStorage item. It will be rendered in UTF-16 if possible; if not, it
             will be shown as a string repr of bytes.
+            :param seq: The sequence number of the key.
+            :param state: The state of the record (live or deleted).
+            :param source_path: The path to the source of the record.
             :param last_modified: Approximation of time content under this origin was last modified.
             If the LocalStorage items were stored in SQLite, this timestamp is when that SQLite file was last modified.
             This means copying the file or otherwise altering the LocalStorage SQLite file's metadata will change this
@@ -304,11 +311,15 @@ class WebBrowser(object):
             If the LocalStorage items were stored in LevelDB, this will be blank.
             """
             super(WebBrowser.LocalStorageItem, self).__init__(
-                'local storage', profile=profile, origin=origin, key=key, value=value, last_modified=last_modified)
+                'local storage', profile=profile, origin=origin, key=key, value=value, seq=seq, state=state,
+                source_path=source_path, last_modified=last_modified)
             self.profile = profile
             self.origin = origin
             self.key = key
             self.value = value
+            self.seq = seq
+            self.state = state
+            self.source_path = source_path
             self.last_modified = last_modified
 
     class FileSystemItem(StorageItem):

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -274,7 +274,7 @@ class WebBrowser(object):
 
     class StorageItem(object):
         def __init__(self, item_type, profile, origin, key, value=None, seq=None, state=None, source_path=None,
-                     last_modified=None, interpretation=None):
+                     last_modified=None, interpretation=None, file_exists=None, file_size=None, magic_results=None):
             self.row_type = item_type
             self.profile = profile
             self.origin = origin
@@ -285,6 +285,9 @@ class WebBrowser(object):
             self.source_path = source_path
             self.last_modified = last_modified
             self.interpretation = interpretation
+            self.file_exists = file_exists
+            self.file_size = file_size
+            self.magic_results = magic_results
 
         def __lt__(self, other):
             return self.origin < other.origin
@@ -323,10 +326,12 @@ class WebBrowser(object):
             self.last_modified = last_modified
 
     class FileSystemItem(StorageItem):
-        def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None):
+        def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None,
+                     file_exists=None, file_size=None, magic_results=None):
             super(WebBrowser.FileSystemItem, self).__init__(
                 'file system', profile=profile, origin=origin, key=key, value=value, seq=seq, state=state,
-                source_path=source_path, last_modified=last_modified)
+                source_path=source_path, last_modified=last_modified, file_exists=file_exists,
+                file_size=file_size, magic_results=magic_results)
             self.profile = profile
             self.origin = origin
             self.key = key
@@ -335,3 +340,6 @@ class WebBrowser(object):
             self.state = state
             self.source_path = source_path
             self.last_modified = last_modified
+            self.file_exists = file_exists
+            self.file_size = file_size
+            self.magic_results = magic_results

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -323,11 +323,15 @@ class WebBrowser(object):
             self.last_modified = last_modified
 
     class FileSystemItem(StorageItem):
-        def __init__(self, profile, origin, key, value, last_modified=None):
+        def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None):
             super(WebBrowser.FileSystemItem, self).__init__(
-                'file system', profile=profile, origin=origin, key=key, value=value, last_modified=last_modified)
+                'file system', profile=profile, origin=origin, key=key, value=value, seq=seq, state=state,
+                source_path=source_path, last_modified=last_modified)
             self.profile = profile
             self.origin = origin
             self.key = key
             self.value = value
+            self.seq = seq
+            self.state = state
+            self.source_path = source_path
             self.last_modified = last_modified

--- a/pyhindsight/lib/ccl_chrome_indexeddb/LICENSE
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyhindsight/lib/ccl_chrome_indexeddb/README.md
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/README.md
@@ -1,0 +1,129 @@
+# ccl_chrome_indexeddb
+This repository contains (sometimes partial) re-implementations of the technologies involved in reading IndexedDB data 
+in Chrome-esque applications.
+This includes:
+* Snappy decompression
+* LevelDB
+* V8 object deserialization
+* Blink object deserialization
+* IndexedDB wrapper
+
+### Blog
+Read a blog on the subject here: https://www.cclsolutionsgroup.com/post/indexeddb-on-chromium
+
+### Caveats
+There is a fair amount of work yet to be done in terms of documentation, but 
+the modules should be fine for pulling data out of IndexedDB, with the following
+caveats:
+
+#### LevelDB deleted data
+The LevelDB module will spit out live and deleted/old versions of records
+indiscriminately; it's possible to differentiate between them with some
+work, but that hasn't really been baked into the modules as they currently
+stand. So you are getting deleted data "for free" currently...whether you
+want it or not.
+
+#### Blink data types
+I am fairly satisfied that all the possible V8 object types are accounted for
+(but I'm happy to be shown otherwise and get that fixed of course!), but it
+is likely that the hosted Blink objects aren't all there yet; so if you hit
+upon an error coming from inside ccl_blink_value_deserializer and can point
+me towards test data, I'd be very thankful!
+
+#### Cyclic references
+It is noted in the V8 source that recursive referencing is possible in the
+serialization, we're not yet accounting for that so if Python throws a
+`RecursionError` that's likely what you're seeing. The plan is to use a 
+similar approach to ccl_bplist where the collection types are subclassed and
+do Just In Time resolution of the items, but that isn't done yet.
+
+## Using the modules
+There are two methods for accessing records - a more pythonic API using a set of 
+wrapper objects and a raw API which doesn't mask the underlying workings. There is
+unlikely to be much benefit to using the raw API in most cases, so the wrapper objects
+are recommended in most cases.
+
+### Wrapper API
+```python
+import sys
+import ccl_chromium_indexeddb
+
+# assuming command line arguments are paths to the .leveldb and .blob folders
+leveldb_folder_path = sys.argv[1]
+blob_folder_path = sys.argv[2]
+
+# open the indexedDB:
+wrapper = ccl_chromium_indexeddb.WrappedIndexDB(leveldb_folder_path, blob_folder_path)
+
+# You can check the databases present using `wrapper.database_ids`
+
+# Databases can be accessed from the wrapper in a number of ways:
+db = wrapper[2]  # accessing database using id number
+db = wrapper["MyTestDatabase"]  # accessing database using name (only valid for single origin indexedDB instances)
+db = wrapper["MyTestDatabase", "file__0@1"]  # accessing the database using name and origin
+# NB using name and origin is likely the preferred option in most cases
+
+# The wrapper object also supports checking for databases using `in`
+
+# You can check for object store names using `db.object_store_names`
+
+# Object stores can be accessed from the database in a number of ways:
+obj_store = db[1]  # accessing object store using id number
+obj_store = db["store"]  # accessing object store using name
+
+# Records can then be accessed by iterating the object store in a for-loop
+for record in obj_store.iterate_records():
+    print(record.key)
+    print(record.value)
+
+    # if this record contained a FileInfo object somewhere linking
+    # to data stored in the blob dir, we could access that data like
+    # so (assume the "file" key in the record value is our FileInfo):
+    with record.get_blob_stream(record.value["file"]) as f:
+        file_data = f.read()
+
+```
+
+### Raw access API
+```python
+import sys
+import ccl_chromium_indexeddb
+
+# assuming command line arguments are paths to the .leveldb and .blob folders
+leveldb_folder_path = sys.argv[1]
+blob_folder_path = sys.argv[2]
+
+# open the database:
+db = ccl_chromium_indexeddb.IndexedDb(leveldb_folder_path, blob_folder_path)
+
+# there can be multiple databases, so we need to iterate through them (NB 
+# DatabaseID objects contain additional metadata, they aren't just ints):
+for db_id_meta in db.global_metadata.db_ids:
+    # and within each database, there will be multiple object stores so we
+    # will need to know the maximum object store number (this process will be
+    # cleaned up in future releases):
+    max_objstore_id = db.get_database_metadata(
+            db_id_meta.dbid_no, 
+            ccl_chromium_indexeddb.DatabaseMetadataType.MaximumObjectStoreId)
+    
+    # if the above returns None, then there are no stores in this db
+    if max_objstore_id is None:
+        continue
+
+    # there may be multiple object stores, so again, we iterate through them
+    # this time based on the id number. Object stores start at id 1 and the
+    # max_objstore_id is inclusive:
+    for obj_store_id in range(1, max_objstore_id + 1):
+        # now we can ask the indexeddb wrapper for all records for this db
+        # and object store:
+        for record in db.iterate_records(db_id_meta.dbid_no, obj_store_id):
+            print(f"key: {record.key}")
+            print(f"key: {record.value}")
+
+            # if this record contained a FileInfo object somewhere linking
+            # to data stored in the blob dir, we could access that data like
+            # so (assume the "file" key in the record value is our FileInfo):
+            with record.get_blob_stream(record.value["file"]) as f:
+                file_data = f.read()
+```
+

--- a/pyhindsight/lib/ccl_chrome_indexeddb/ccl_blink_value_deserializer.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/ccl_blink_value_deserializer.py
@@ -1,0 +1,210 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import sys
+import enum
+import typing
+from dataclasses import dataclass
+
+import ccl_v8_value_deserializer
+
+# See: https://chromium.googlesource.com/chromium/src/third_party/+/master/blink/renderer/bindings/core/v8/serialization
+
+# WebCoreStrings are read as (length:uint32_t, string:UTF8[length]).
+# RawStrings are read as (length:uint32_t, string:UTF8[length]).
+# RawUCharStrings are read as
+#     (length:uint32_t, string:UChar[length/sizeof(UChar)]).
+# RawFiles are read as
+#     (path:WebCoreString, url:WebCoreStrng, type:WebCoreString).
+# There is a reference table that maps object references (uint32_t) to
+# v8::Values.
+# Tokens marked with (ref) are inserted into the reference table and given the
+# next object reference ID after decoding.
+# All tags except InvalidTag, PaddingTag, ReferenceCountTag, VersionTag,
+# GenerateFreshObjectTag and GenerateFreshArrayTag push their results to the
+# deserialization stack.
+# There is also an 'open' stack that is used to resolve circular references.
+# Objects or arrays may contain self-references. Before we begin to deserialize
+# the contents of these values, they are first given object reference IDs (by
+# GenerateFreshObjectTag/GenerateFreshArrayTag); these reference IDs are then
+# used with ObjectReferenceTag to tie the recursive knot.
+
+__version__ = "0.1"
+__description__ = "Partial reimplementation of the Blink Javascript Object Serialization"
+__contact__ = "Alex Caithness"
+
+__DEBUG = True
+
+
+def log(msg, debug_only=True):
+    if __DEBUG or not debug_only:
+        caller_name = sys._getframe(1).f_code.co_name
+        caller_line = sys._getframe(1).f_code.co_firstlineno
+        print(f"{caller_name} ({caller_line}):\t{msg}")
+
+
+class BlobIndexType(enum.Enum):
+    Blob = 0
+    File = 1
+
+
+@dataclass
+class BlobIndex:
+    index_type: BlobIndexType
+    index_id: int
+
+
+class Constants:
+    tag_kMessagePortTag = b"M"  # index:int -> MessagePort. Fills the result with
+                                # transferred MessagePort.
+    tag_kMojoHandleTag = b"h"   # index:int -> MojoHandle. Fills the result with
+                                # transferred MojoHandle.
+    tag_kBlobTag = b"b"         # uuid:WebCoreString, type:WebCoreString, size:uint64_t ->
+                                # Blob (ref)
+    tag_kBlobIndexTag = b"i"    # index:int32_t -> Blob (ref)
+    tag_kFileTag = b"f"         # file:RawFile -> File (ref)
+    tag_kFileIndexTag = b"e"    # index:int32_t -> File (ref)
+    tag_kDOMFileSystemTag = b"d"  # type : int32_t, name:WebCoreString,
+                                  # uuid:WebCoreString -> FileSystem (ref)
+    tag_kNativeFileSystemFileHandleTag = b"n"  # name:WebCoreString, index:uint32_t
+                                               # -> NativeFileSystemFileHandle (ref)
+    tag_kNativeFileSystemDirectoryHandleTag = b"N"  # name:WebCoreString, index:uint32_t ->
+                                                   # NativeFileSystemDirectoryHandle (ref)
+    tag_kFileListTag = b"l"                     # length:uint32_t, files:RawFile[length] -> FileList (ref)
+    tag_kFileListIndexTag = b"L"                # length:uint32_t, files:int32_t[length] -> FileList (ref)
+    tag_kImageDataTag = b"#"                   # tags terminated by ImageSerializationTag::kEnd (see
+                                               # SerializedColorParams.h), width:uint32_t,
+                                               # height:uint32_t, pixelDataLength:uint64_t,
+                                               # data:byte[pixelDataLength]
+                                               # -> ImageData (ref)
+    tag_kImageBitmapTag = b"g"        # tags terminated by ImageSerializationTag::kEnd (see
+                                      # SerializedColorParams.h), width:uint32_t,
+                                      # height:uint32_t, pixelDataLength:uint32_t,
+                                      # data:byte[pixelDataLength]
+                                      # -> ImageBitmap (ref)
+    tag_kImageBitmapTransferTag = "G"       # index:uint32_t -> ImageBitmap. For ImageBitmap transfer
+    tag_kOffscreenCanvasTransferTag = b"H"  # index, width, height, id,
+                                            # filter_quality::uint32_t ->
+                                            # OffscreenCanvas. For OffscreenCanvas
+                                            # transfer
+    tag_kReadableStreamTransferTag = b"r"    # index:uint32_t
+    tag_kTransformStreamTransferTag = b"m"   # index:uint32_t
+    tag_kWritableStreamTransferTag = b"w"    # index:uint32_t
+    tag_kDOMPointTag = b"Q"                  # x:Double, y:Double, z:Double, w:Double
+    tag_kDOMPointReadOnlyTag = b"W"          # x:Double, y:Double, z:Double, w:Double
+    tag_kDOMRectTag = b"E"                   # x:Double, y:Double, width:Double, height:Double
+    tag_kDOMRectReadOnlyTag = b"R"           # x:Double, y:Double, width:Double, height:Double
+    tag_kDOMQuadTag = b"T"                   # p1:Double, p2:Double, p3:Double, p4:Double
+    tag_kDOMMatrixTag = b"Y"                 # m11..m44: 16 Double
+    tag_kDOMMatrixReadOnlyTag = b"U"         # m11..m44: 16 Double
+    tag_kDOMMatrix2DTag = b"I"               # a..f: 6 Double
+    tag_kDOMMatrix2DReadOnlyTag = b"O"       # a..f: 6 Double
+    tag_kCryptoKeyTag = b"K"                 # subtag:byte, props, usages:uint32_t,
+    # keyDataLength:uint32_t, keyData:byte[keyDataLength]
+    #                 If subtag=AesKeyTag:
+    #                     props = keyLengthBytes:uint32_t, algorithmId:uint32_t
+    #                 If subtag=HmacKeyTag:
+    #                     props = keyLengthBytes:uint32_t, hashId:uint32_t
+    #                 If subtag=RsaHashedKeyTag:
+    #                     props = algorithmId:uint32_t, type:uint32_t,
+    #                     modulusLengthBits:uint32_t,
+    #                     publicExponentLength:uint32_t,
+    #                     publicExponent:byte[publicExponentLength],
+    #                     hashId:uint32_t
+    #                 If subtag=EcKeyTag:
+    #                     props = algorithmId:uint32_t, type:uint32_t,
+    #                     namedCurve:uint32_t
+    tag_kRTCCertificateTag = b"k"  # length:uint32_t, pemPrivateKey:WebCoreString,
+    # pemCertificate:WebCoreString
+    tag_kRTCEncodedAudioFrameTag = b"A"  # uint32_t -> transferred audio frame ID
+    tag_kRTCEncodedVideoFrameTag = b"V"  # uint32_t -> transferred video frame ID
+    tag_kVideoFrameTag = b"v"            # uint32_t -> transferred video frame ID
+
+    # The following tags were used by the Shape Detection API implementation
+    # between M71 and M81. During these milestones, the API was always behind
+    # a flag. Usage was removed in https:#crrev.com/c/2040378.
+    tag_kDeprecatedDetectedBarcodeTag = b"B"
+    tag_kDeprecatedDetectedFaceTag = b"F"
+    tag_kDeprecatedDetectedTextTag = b"t"
+
+    tag_kDOMExceptionTag = b"x"  # name:String,message:String,stack:String
+    tag_kVersionTag = b"\xff"  # version:uint32_t -> Uses this as the file version.
+
+
+class BlinkV8Deserializer:
+    def _read_varint(self, stream) -> int:
+        return ccl_v8_value_deserializer.read_le_varint(stream)[0]
+
+    def _read_file_index(self, stream: typing.BinaryIO) -> BlobIndex:
+        return BlobIndex(BlobIndexType.File, self._read_varint(stream))
+
+    def _read_file_list_index(self, stream: typing.BinaryIO) -> typing.Iterable[BlobIndex]:
+        length = self._read_varint(stream)
+        result = [self._read_file_index(stream) for _ in range(length)]
+        return result
+
+    def _not_implemented(self, stream):
+        raise NotImplementedError()
+
+    def read(self, stream: typing.BinaryIO) -> typing.Any:
+        tag = stream.read(1)
+
+        func = {
+            Constants.tag_kMessagePortTag: lambda x: self._not_implemented(x),
+            Constants.tag_kMojoHandleTag: lambda x: self._not_implemented(x),
+            Constants.tag_kBlobTag: lambda x: self._not_implemented(x),
+            Constants.tag_kBlobIndexTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileIndexTag: lambda x: self._read_file_index(x),
+            Constants.tag_kDOMFileSystemTag: lambda x: self._not_implemented(x),
+            Constants.tag_kNativeFileSystemFileHandleTag: lambda x: self._not_implemented(x),
+            Constants.tag_kNativeFileSystemDirectoryHandleTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileListTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileListIndexTag: lambda x: self._read_file_list_index(x),
+            Constants.tag_kImageDataTag: lambda x: self._not_implemented(x),
+            Constants.tag_kImageBitmapTag: lambda x: self._not_implemented(x),
+            Constants.tag_kImageBitmapTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kOffscreenCanvasTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kReadableStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kTransformStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kWritableStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMPointTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMPointReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMRectTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMRectReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMQuadTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrixTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrixReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrix2DTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrix2DReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kCryptoKeyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kRTCCertificateTag: lambda x: self._not_implemented(x),
+            Constants.tag_kRTCEncodedAudioFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kRTCEncodedVideoFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kVideoFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMExceptionTag: lambda x: self._not_implemented(x)
+        }.get(tag)
+
+        if func is None:
+            raise ValueError(f"Unknown tag: {tag}")
+
+        return func(stream)

--- a/pyhindsight/lib/ccl_chrome_indexeddb/ccl_chromium_indexeddb.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/ccl_chromium_indexeddb.py
@@ -1,0 +1,653 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import struct
+import os
+import pathlib
+import io
+import enum
+import datetime
+import dataclasses
+import types
+import typing
+
+import ccl_leveldb
+import ccl_v8_value_deserializer
+import ccl_blink_value_deserializer
+
+__version__ = "0.2"
+__description__ = "Module for reading Chromium IndexedDB LevelDB databases."
+__contact__ = "Alex Caithness"
+
+
+# TODO: need to go through and ensure that we have endianness right in all cases
+#  (it should sit behind a switch for integers, fixed for most other stuff)
+
+
+def _read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False):
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    limit = 5 if is_google_32bit else 10
+    while i < limit:
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False):
+    x = _read_le_varint(stream, is_google_32bit=is_google_32bit)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def _le_varint_from_bytes(data: bytes):
+    with io.BytesIO(data) as buff:
+        return _read_le_varint(buff)
+
+
+def le_varint_from_bytes(data: bytes):
+    with io.BytesIO(data) as buff:
+        return read_le_varint(buff)
+
+
+class IdbKeyType(enum.IntEnum):
+    Null = 0
+    String = 1
+    Date = 2
+    Number = 3
+    Array = 4
+    MinKey = 5
+    Binary = 6
+
+
+class IdbKey:
+    # See: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_leveldb_coding.cc
+    def __init__(self, buffer: bytes):
+        self.raw_key = buffer
+        self.key_type = IdbKeyType(buffer[0])
+        raw_key = buffer[1:]
+
+        if self.key_type == IdbKeyType.Null:
+            self.value = None
+            self._raw_length = 1
+        elif self.key_type == IdbKeyType.String:
+            str_len, varint_raw = _le_varint_from_bytes(raw_key)
+            self.value = raw_key[len(varint_raw):len(varint_raw) + str_len * 2].decode("utf-16-be")
+            self._raw_length = 1 + len(varint_raw) + str_len * 2
+        elif self.key_type == IdbKeyType.Date:
+            ts, = struct.unpack("<d", raw_key[0:8])
+            self.value = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=ts)
+            self._raw_length = 9
+        elif self.key_type == IdbKeyType.Number:
+            self.value = struct.unpack("<d", raw_key[0:8])[0]
+            self._raw_length = 9
+        elif self.key_type == IdbKeyType.Array:
+            array_count, varint_raw = _le_varint_from_bytes(raw_key)
+            raw_key = raw_key[len(varint_raw):]
+            self.value = []
+            self._raw_length = 1 + len(varint_raw)
+            for i in range(array_count):
+                key = IdbKey(raw_key)
+                raw_key = raw_key[key._raw_length:]
+                self._raw_length += key._raw_length
+                self.value.append(key)
+            self.value = tuple(self.value)
+        elif self.key_type == IdbKeyType.MinKey:
+            # TODO: not sure what this actually implies, the code doesn't store a value
+            self.value = None
+            self._raw_length = 1
+            raise NotImplementedError()
+        elif self.key_type == IdbKeyType.Binary:
+            bin_len, varint_raw = _le_varint_from_bytes(raw_key)
+            self.value = raw_key[len(varint_raw):len(varint_raw) + bin_len]
+            self._raw_length = 1 + len(varint_raw) + bin_len
+        else:
+            raise ValueError()  # Shouldn't happen
+
+    def __repr__(self):
+        return f"<IdbKey {self.value}>"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class IndexedDBExternalObjectType(enum.IntEnum):
+    # see: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_external_object.h
+    Blob = 0
+    File = 1
+    NativeFileSystemHandle = 2
+
+
+class IndexedDBExternalObject:
+    # see: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_backing_store.cc
+    # for encoding.
+
+    def __init__(self, object_type: IndexedDBExternalObjectType, blob_number: typing.Optional[int],
+                 mime_type: typing.Optional[str], size: typing.Optional[int],
+                 file_name: typing.Optional[str], last_modified: typing.Optional[datetime.datetime],
+                 native_file_token: typing.Optional):
+        self.object_type = object_type
+        self.blob_number = blob_number
+        self.mime_type = mime_type
+        self.size = size
+        self.file_name = file_name
+        self.last_modified = last_modified
+        self.native_file_token = native_file_token
+
+    @classmethod
+    def from_stream(cls, stream: typing.BinaryIO):
+        blob_type = IndexedDBExternalObjectType(stream.read(1)[0])
+        if blob_type in (IndexedDBExternalObjectType.Blob, IndexedDBExternalObjectType.File):
+            blob_number = read_le_varint(stream)
+            mime_type_length = read_le_varint(stream)
+            mime_type = stream.read(mime_type_length * 2).decode("utf-16-be")
+            data_size = read_le_varint(stream)
+
+            if blob_type == IndexedDBExternalObjectType.File:
+                file_name_length = read_le_varint(stream)
+                file_name = stream.read(file_name_length * 2).decode("utf-16-be")
+                x, x_raw = _read_le_varint(stream)
+                last_modified_td = datetime.timedelta(microseconds=x)
+                last_modified = datetime.datetime(1601, 1, 1) + last_modified_td
+                return cls(blob_type, blob_number, mime_type, data_size, file_name,
+                           last_modified, None)
+            else:
+                return cls(blob_type, blob_number, mime_type, data_size, None, None, None)
+        else:
+            raise NotImplementedError()
+
+
+@dataclasses.dataclass(frozen=True)
+class DatabaseId:
+    dbid_no: int
+    origin: str
+    name: str
+
+
+class GlobalMetadata:
+    def __init__(self, raw_meta_dict: dict):
+        # TODO: more of these meta types if required
+        self.backing_store_schema_version = None
+        if raw_schema_version := raw_meta_dict.get("\x00\x00\x00\x00\x00"):
+            self.backing_store_schema_version = le_varint_from_bytes(raw_schema_version)
+
+        self.max_allocated_db_id = None
+        if raw_max_db_id := raw_meta_dict.get("\x00\x00\x00\x00\x01"):
+            self.max_allocated_db_id = le_varint_from_bytes(raw_max_db_id)
+
+        database_ids_raw = (raw_meta_dict[x] for x in raw_meta_dict
+                            if x.startswith(b"\x00\x00\x00\x00\xc9"))
+
+        dbids = []
+        for dbid_rec in database_ids_raw:
+            with io.BytesIO(dbid_rec.key[5:]) as buff:
+                origin_length = read_le_varint(buff)
+                origin = buff.read(origin_length * 2).decode("utf-16-be")
+                db_name_length = read_le_varint(buff)
+                db_name = buff.read(db_name_length * 2).decode("utf-16-be")
+
+            db_id_no = le_varint_from_bytes(dbid_rec.value)
+
+            dbids.append(DatabaseId(db_id_no, origin, db_name))
+
+        self.db_ids = tuple(dbids)
+
+
+class DatabaseMetadataType(enum.IntEnum):
+    OriginName = 0  # String
+    DatabaseName = 1  # String
+    IdbVersionString = 2  # String (and obsolete)
+    MaximumObjectStoreId = 3  # Int
+    IdbVersion = 4  # Varint
+    BlobNumberGeneratorCurrentNumber = 5  # Varint
+
+
+class DatabaseMetadata:
+    def __init__(self, raw_meta: dict):
+        self._metas = types.MappingProxyType(raw_meta)
+
+    def get_meta(self, db_id: int, meta_type: DatabaseMetadataType) -> typing.Optional[typing.Union[str, int]]:
+        record = self._metas.get((db_id, meta_type))
+        if not record:
+            return None
+
+        if meta_type == DatabaseMetadataType.MaximumObjectStoreId:
+            return le_varint_from_bytes(record.value)
+
+        # TODO
+        raise NotImplementedError()
+
+
+class ObjectStoreMetadataType(enum.IntEnum):
+    StoreName = 0  # String
+    KeyPath = 1  # IDBKeyPath
+    AutoIncrementFlag = 2  # Bool
+    IsEvictable = 3  # Bool (and obsolete apparently)
+    LastVersionNumber = 4  # Int
+    MaximumAllocatedIndexId = 5  # Int
+    HasKeyPathFlag = 6  # Bool (and obsolete apparently)
+    KeygeneratorCurrentNumber = 7  # Int
+
+
+class ObjectStoreMetadata:
+    # All metadata fields are prefaced by a 0x00 byte
+    def __init__(self, raw_meta: dict):
+        self._metas = types.MappingProxyType(raw_meta)
+
+    def get_meta(self, db_id: int, obj_store_id: int, meta_type: ObjectStoreMetadataType):
+        record = self._metas.get((db_id, obj_store_id, meta_type))
+        if not record:
+            return None
+
+        if meta_type == ObjectStoreMetadataType.StoreName:
+            return record.value.decode("utf-16-be")
+
+        # TODO
+        raise NotImplementedError()
+
+
+class IndexedDbRecord:
+    def __init__(self, owner: "IndexedDb", db_id: int, obj_store_id: int, key: IdbKey, value: typing.Any):
+        self.owner = owner
+        self.db_id = db_id
+        self.obj_store_id = obj_store_id
+        self.key = key
+        self.value = value
+
+    def resolve_blob_index(self, blob_index: ccl_blink_value_deserializer.BlobIndex) -> IndexedDBExternalObject:
+        """Resolve a ccl_blink_value_deserializer.BlobIndex to its IndexedDBExternalObject
+         to get metadata (file name, timestamps, etc)"""
+        return self.owner.get_blob_info(self.db_id, self.obj_store_id, self.key.raw_key, blob_index.index_id)
+
+    def get_blob_stream(self, blob_index: ccl_blink_value_deserializer.BlobIndex) -> typing.BinaryIO:
+        """Resolve a ccl_blink_value_deserializer.BlobIndex to a stream of its content"""
+        return self.owner.get_blob(self.db_id, self.obj_store_id, self.key.raw_key, blob_index.index_id)
+
+
+class IndexedDb:
+    # This will be informative for a lot of the data below:
+    # https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/docs/leveldb_coding_scheme.md
+
+    # Of note, the first byte of the key defines the length of the db_id, obj_store_id and index_id in bytes:
+    # 0b xxxyyyzz (x = db_id size - 1, y = obj_store size - 1, z = index_id - 1)
+    # Currently I just assume that everything falls between 1 and 127 for simplicity as it makes scanning the keys
+    # lots easier.
+    def __init__(self, leveldb_dir: os.PathLike, leveldb_blob_dir: os.PathLike = None):
+        self._db = ccl_leveldb.RawLevelDb(leveldb_dir)
+        self._blob_dir = leveldb_blob_dir
+        self.global_metadata = GlobalMetadata(self._get_raw_global_metadata())
+        self.database_metadata = DatabaseMetadata(self._get_raw_database_metadata())
+        self.object_store_meta = ObjectStoreMetadata(self._get_raw_object_store_metadata())
+
+        self._blob_lookup_cache = {}
+
+    @staticmethod
+    def make_prefix(db_id: int, obj_store_id: int, index_id: int) -> bytes:
+        def count_bytes(val):
+            i = 0
+            while val > 0:
+                i += 1
+                val = val >> 8
+            return i
+
+        def yield_le_bytes(val):
+            if val < 0:
+                raise ValueError
+            while val > 0:
+                yield val & 0xff
+                val >> 8
+
+        db_id_size = count_bytes(db_id)
+        obj_store_id_size = count_bytes(obj_store_id)
+        index_id_size = count_bytes(index_id)
+
+        if db_id_size > 8 or obj_store_id_size > 8 or index_id_size > 4:
+            raise ValueError("id sizes are too big")
+
+        byte_one = ((db_id_size - 1) << 5) | ((obj_store_id_size - 1) << 2) | index_id_size
+        return bytes([byte_one, *yield_le_bytes(db_id), *yield_le_bytes(obj_store_id), *yield_le_bytes(index_id)])
+
+    def get_database_metadata(self, db_id: int, meta_type: DatabaseMetadataType):
+        return self.database_metadata.get_meta(db_id, meta_type)
+
+    def get_object_store_metadata(self, db_id: int, obj_store_id: int, meta_type: ObjectStoreMetadataType):
+        return self.object_store_meta.get_meta(db_id, obj_store_id, meta_type)
+
+    def _get_raw_global_metadata(self, live_only=True) -> typing.Dict[bytes, ccl_leveldb.Record]:
+        # Global metadata always has the prefix 0 0 0 0
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+        meta = {}
+        for record in self._db.iterate_records_raw(reverse=True):
+            if record.key.startswith(b"\x00\x00\x00\x00") and record.state == ccl_leveldb.KeyState.Live:
+                # we only want live keys and the newest version thereof (highest seq)
+                if record.key not in meta or meta[record.key].seq < record.seq:
+                    meta[record.key] = record
+
+        return meta
+
+    def _get_raw_database_metadata(self, live_only=True):
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+
+        db_meta = {}
+
+        for db_id in self.global_metadata.db_ids:
+            if db_id.dbid_no > 0x7f:
+                raise NotImplementedError("there could be this many dbs, but I don't support it yet")
+
+            prefix = bytes([0, db_id.dbid_no, 0, 0])
+            for record in self._db.iterate_records_raw(reverse=True):
+                if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
+                    # we only want live keys and the newest version thereof (highest seq)
+                    meta_type = record.key[len(prefix)]
+                    db_meta[(db_id.dbid_no, meta_type)] = record
+
+        return db_meta
+
+    def _get_raw_object_store_metadata(self, live_only=True):
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+
+        os_meta = {}
+
+        for db_id in self.global_metadata.db_ids:
+            if db_id.dbid_no > 0x7f:
+                raise NotImplementedError("there could be this many dbs, but I don't support it yet")
+
+            prefix = bytes([0, db_id.dbid_no, 0, 0, 50])
+
+            for record in self._db.iterate_records_raw(reverse=True):
+                if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
+                    # we only want live keys and the newest version thereof (highest seq)
+                    objstore_id, varint_raw = _le_varint_from_bytes(record.key[len(prefix):])
+                    meta_type = record.key[len(prefix) + len(varint_raw)]
+
+                    old_version = os_meta.get((db_id.dbid_no, objstore_id, meta_type))
+
+                    if old_version is None or old_version.seq < record.seq:
+                        os_meta[(db_id.dbid_no, objstore_id, meta_type)] = record
+
+        return os_meta
+
+    def iterate_records(
+            self, db_id: int, store_id: int, *,
+            live_only=True, bad_deserializer_data_handler: typing.Callable[[IdbKey, bytes], typing.Any] = None):
+        if db_id > 0x7f or store_id > 0x7f:
+            raise NotImplementedError("there could be this many dbs or object stores, but I don't support it yet")
+
+        blink_deserializer = ccl_blink_value_deserializer.BlinkV8Deserializer()
+
+        # goodness me this is a slow way of doing things
+        prefix = bytes([0, db_id, store_id, 1])
+        for record in self._db.iterate_records_raw():
+            if record.key.startswith(prefix):
+                key = IdbKey(record.key[len(prefix):])
+                if not record.value:
+                    # empty values will obviously fail, returning None is probably better than dying.
+                    return key, None
+                value_version, varint_raw = _le_varint_from_bytes(record.value)
+                val_idx = len(varint_raw)
+                # read the blink envelope
+                blink_type_tag = record.value[val_idx]
+                if blink_type_tag != 0xff:
+                    # TODO: probably don't want to fail hard here long term...
+                    raise ValueError("Blink type tag not present")
+                val_idx += 1
+
+                blink_version, varint_raw = _le_varint_from_bytes(record.value[val_idx:])
+
+                val_idx += len(varint_raw)
+
+                obj_raw = io.BytesIO(record.value[val_idx:])
+                deserializer = ccl_v8_value_deserializer.Deserializer(
+                    obj_raw, host_object_delegate=blink_deserializer.read)
+                try:
+                    value = deserializer.read()
+                except Exception:
+                    if bad_deserializer_data_handler is not None:
+                        bad_deserializer_data_handler(key, record.value[val_idx:])
+                    raise
+                yield IndexedDbRecord(self, db_id, store_id, key, value)
+
+    def get_blob_info(self, db_id: int, store_id: int, raw_key: bytes, file_index: int) -> IndexedDBExternalObject:
+        if db_id > 0x7f or store_id > 0x7f:
+            raise NotImplementedError("there could be this many dbs, but I don't support it yet")
+
+        if result := self._blob_lookup_cache.get((db_id, store_id, raw_key, file_index)):
+            return result
+
+        # goodness me this is a slow way of doing things,
+        # TODO: we should at least cache along the way to our record
+        prefix = bytes([0, db_id, store_id, 3])
+        for record in self._db.iterate_records_raw():
+            if record.key.startswith(prefix):
+                buff = io.BytesIO(record.value)
+                idx = 0
+                while buff.tell() < len(record.value):
+                    blob_info = IndexedDBExternalObject.from_stream(buff)
+                    self._blob_lookup_cache[(db_id, store_id, raw_key, idx)] = blob_info
+                    idx += 1
+                break
+
+        if result := self._blob_lookup_cache.get((db_id, store_id, raw_key, file_index)):
+            return result
+        else:
+            raise KeyError((db_id, store_id, raw_key, file_index))
+
+    def get_blob(self, db_id: int, store_id: int, raw_key: bytes, file_index: int) -> typing.BinaryIO:
+        # Some detail here: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/docs/README.md
+        if self._blob_dir is None:
+            raise ValueError("Can't resolve blob if blob dir is not set")
+        info = self.get_blob_info(db_id, store_id, raw_key, file_index)
+
+        # path will be: origin.blob/database id/top 16 bits of blob number with two digits/blob number
+        # TODO: check if this is still the case on non-windows systems
+        path = pathlib.Path(self._blob_dir, str(db_id), f"{info.blob_number >> 8:02x}", f"{info.blob_number:x}")
+
+        if path.exists():
+            return path.open("rb")
+
+        raise FileNotFoundError(path)
+
+    @property
+    def database_path(self):
+        return self._db.in_dir_path
+
+
+class WrappedObjectStore:
+    def __init__(self, raw_db: IndexedDb,  dbid_no: int, obj_store_id: int):
+        self._raw_db = raw_db
+        self._dbid_no = dbid_no
+        self._obj_store_id = obj_store_id
+
+    @property
+    def object_store_id(self):
+        return self._obj_store_id
+
+    @property
+    def name(self) -> str:
+        return self._raw_db.get_object_store_metadata(
+            self._dbid_no, self._obj_store_id, ObjectStoreMetadataType.StoreName)
+
+    def get_blob(self, raw_key: bytes, file_index: int) -> typing.BinaryIO:
+        return self._raw_db.get_blob(self._dbid_no, self.object_store_id, raw_key, file_index)
+
+    # def __iter__(self):
+    #     yield from self._raw_db.iterate_records(self._dbid_no, self._obj_store_id)
+
+    def iterate_records(self):
+        yield from self._raw_db.iterate_records(self._dbid_no, self._obj_store_id)
+
+    def __repr__(self):
+        return f"<WrappedObjectStore: object_store_id={self.object_store_id}; name={self.name}>"
+
+
+class WrappedDatabase:
+    def __init__(self, raw_db: IndexedDb,  dbid: DatabaseId):
+        self._raw_db = raw_db
+        self._dbid = dbid
+
+        names = []
+        for obj_store_id in range(1, self.object_store_count + 1):
+            names.append(self._raw_db.get_object_store_metadata(
+                self.db_number, obj_store_id, ObjectStoreMetadataType.StoreName))
+        self._obj_store_names = tuple(names)
+        # pre-compile object store wrappers as there's little overhead
+        self._obj_stores = tuple(
+            WrappedObjectStore(self._raw_db, self.db_number, i) for i in range(1, self.object_store_count + 1))
+
+    @property
+    def name(self) -> str:
+        return self._dbid.name
+
+    @property
+    def origin(self) -> str:
+        return self._dbid.origin
+
+    @property
+    def db_number(self) -> int:
+        return self._dbid.dbid_no
+
+    @property
+    def object_store_count(self) -> int:
+        # NB obj store ids are enumerated from 1.
+        return self._raw_db.get_database_metadata(
+            self.db_number,
+            DatabaseMetadataType.MaximumObjectStoreId) or 0  # returns None if there are none.
+
+    @property
+    def object_store_names(self) -> typing.Iterable[str]:
+        yield from self._obj_store_names
+
+    def get_object_store_by_id(self, obj_store_id: int) -> WrappedObjectStore:
+        if obj_store_id > 0 and obj_store_id <= self.object_store_count:
+            return self._obj_stores[obj_store_id - 1]
+        raise ValueError("obj_store_id must be greater than zero and less or equal to object_store_count "
+                         "NB object stores are enumerated from 1 - there is no store with id 0")
+
+    def get_object_store_by_name(self, name: str) -> WrappedObjectStore:
+        if name in self:
+            return self.get_object_store_by_id(self._obj_store_names.index(name) + 1)
+        raise KeyError(f"{name} is not an object store in this database")
+
+    def __len__(self):
+        len(self._obj_stores)
+
+    def __contains__(self, item):
+        return item in self._obj_store_names
+
+    def __getitem__(self, item) -> "WrappedObjectStore":
+        if isinstance(item, int):
+            return self.get_object_store_by_id(item)
+        elif isinstance(item, str):
+            return self.get_object_store_by_name(item)
+        raise TypeError("Key can only be str (name) or int (id number)")
+
+    def __repr__(self):
+        return f"<WrappedDatabase: id={self.db_number}; name={self.name}; origin={self.origin}>"
+
+
+class WrappedIndexDB:
+    def __init__(self, leveldb_dir: os.PathLike, leveldb_blob_dir: os.PathLike = None):
+        self._raw_db = IndexedDb(leveldb_dir, leveldb_blob_dir)
+        self._multiple_origins = len(set(x.origin for x in self._raw_db.global_metadata.db_ids)) > 1
+
+        self._db_number_lookup = {
+            x.dbid_no: WrappedDatabase(self._raw_db, x)
+            for x in self._raw_db.global_metadata.db_ids}
+        # set origin to 0 if there's only 1 and we'll ignore it in all lookups
+        self._db_name_lookup = {
+            (x.name, x.origin if self.has_multiple_origins else 0): x
+            for x in self._db_number_lookup.values()}
+
+    @property
+    def database_count(self):
+        return len(self._db_number_lookup)
+
+    @property
+    def database_ids(self):
+        yield from self._raw_db.global_metadata.db_ids
+
+    @property
+    def has_multiple_origins(self):
+        return self._multiple_origins
+
+    def __len__(self):
+        len(self._db_number_lookup)
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            if self.has_multiple_origins:
+                raise ValueError(
+                    "Database contains multiple origins, lookups must be provided as a tuple of (name, origin)")
+            return (item, 0) in self._db_name_lookup
+        elif isinstance(item, tuple) and len(item) == 2:
+            name, origin = item
+            if not self.has_multiple_origins:
+                origin = 0  # origin ignored if not needed
+            return (name, origin) in self._db_name_lookup
+        elif isinstance(item, int):
+            return item in self._db_number_lookup
+        else:
+            raise TypeError("keys must be provided as a tuple of (name, origin) or a str (if only single origin) or int")
+
+    def __getitem__(self, item: typing.Union[int, str, typing.Tuple[str, str]]) -> "WrappedDatabase":
+        if isinstance(item, int):
+            if item in self._db_number_lookup:
+                return self._db_number_lookup[item]
+            else:
+                raise KeyError(item)
+        elif isinstance(item, str):
+            if self.has_multiple_origins:
+                raise ValueError(
+                    "Database contains multiple origins, indexes must be provided as a tuple of (name, origin)")
+            if item in self:
+                return self._db_name_lookup[item, 0]
+            else:
+                raise KeyError(item)
+        elif isinstance(item, tuple) and len(item) == 2:
+            name, origin = item
+            if not self.has_multiple_origins:
+                origin = 0  # origin ignored if not needed
+            if (name, origin) in self:
+                return self._db_name_lookup[name, origin]
+            else:
+                raise KeyError(item)
+
+        raise TypeError("Lookups must be one of int, str or tuple of name and origin")
+
+    def __repr__(self):
+        return f"<WrappedIndexDB: {self._raw_db.database_path}>"
+

--- a/pyhindsight/lib/ccl_chrome_indexeddb/ccl_leveldb.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/ccl_leveldb.py
@@ -1,0 +1,570 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import typing
+import struct
+import re
+import os
+import io
+import pathlib
+import dataclasses
+import enum
+from collections import namedtuple
+from types import MappingProxyType
+
+from pyhindsight.lib.ccl_chrome_indexeddb import ccl_simplesnappy
+
+__version__ = "0.2"
+__description__ = "A module for reading LevelDB databases"
+__contact__ = "Alex Caithness"
+
+
+def _read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[typing.Tuple[int, bytes]]:
+    """Read varint from a stream.
+    If the read is successful: returns a tuple of the (unsigned) value and the raw bytes making up that varint,
+    otherwise returns None.
+    Can be switched to limit the varint to 32 bit."""
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    limit = 5 if is_google_32bit else 10
+    while i < limit:
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[int]:
+    """Convenience version of _read_le_varint that only returns the value or None"""
+    x = _read_le_varint(stream, is_google_32bit=is_google_32bit)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def read_length_prefixed_blob(stream: typing.BinaryIO):
+    length = read_le_varint(stream)
+    data = stream.read(length)
+    if len(data) != length:
+        raise ValueError(f"Could not read all data (expected {length}, got {len(data)}")
+    return data
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockHandle:
+    """See: https://github.com/google/leveldb/blob/master/doc/table_format.md
+    A BlockHandle contains an offset and length of a block in an ldb table file"""
+    offset: int
+    length: int
+
+    @classmethod
+    def from_stream(cls, stream: typing.BinaryIO):
+        return cls(read_le_varint(stream), read_le_varint(stream))
+
+    @classmethod
+    def from_bytes(cls, data: bytes):
+        with io.BytesIO(data) as stream:
+            return BlockHandle.from_stream(stream)
+
+
+@dataclasses.dataclass(frozen=True)
+class RawBlockEntry:
+    """Raw key, value for a record in a LDB file Block, along with the offset within the block from which it came from
+    See: https://github.com/google/leveldb/blob/master/doc/table_format.md"""
+    key: bytes
+    value: bytes
+    block_offset: int
+
+
+class FileType(enum.Enum):
+    Ldb = 1
+    Log = 2
+
+
+class KeyState(enum.Enum):
+    Deleted = 0
+    Live = 1
+    Unknown = 2
+
+
+@dataclasses.dataclass(frozen=True)
+class Record:
+    """A record from leveldb; includes details of the origin file, state, etc."""
+
+    key: bytes
+    value: bytes
+    seq: int
+    state: KeyState
+    file_type: FileType
+    origin_file: os.PathLike
+    offset: int
+    was_compressed: bool
+
+    @classmethod
+    def ldb_record(cls, key: bytes, value: bytes, origin_file: os.PathLike,
+                   offset: int, was_compressed: bool):
+        seq = (struct.unpack("<Q", key[-8:])[0]) >> 8
+        if len(key) > 8:
+            state = KeyState.Deleted if key[-8] == 0 else KeyState.Live
+        else:
+            state = KeyState.Unknown
+        return cls(key, value, seq, state, FileType.Ldb, origin_file, offset, was_compressed)
+
+    @classmethod
+    def log_record(cls, key: bytes, value: bytes, seq: int, state: KeyState,
+                   origin_file: os.PathLike, offset: int):
+        return cls(key, value, seq, state, FileType.Log, origin_file, offset, False)
+
+
+class Block:
+    """Block from an .lldb (table) file. See: https://github.com/google/leveldb/blob/master/doc/table_format.md"""
+    def __init__(self, raw: bytes, was_compressed: bool, origin: "LdbFile", offset: int):
+        self._raw = raw
+        self.was_compressed = was_compressed
+        self.origin = origin
+        self.offset = offset
+
+        self._restart_array_count, = struct.unpack("<I", self._raw[-4:])
+        self._restart_array_offset = len(self._raw) - (self._restart_array_count + 1) * 4
+
+    def get_restart_offset(self, index) -> int:
+        offset = self._restart_array_offset + (index * 4)
+        return struct.unpack("<i", self._raw[offset: offset + 4])[0]
+
+    def get_first_entry_offset(self) -> int:
+        return self.get_restart_offset(0)
+
+    def __iter__(self) -> typing.Iterable[RawBlockEntry]:
+        offset = self.get_first_entry_offset()
+        with io.BytesIO(self._raw) as buff:
+            buff.seek(offset)
+
+            key = b""
+
+            while buff.tell() < self._restart_array_offset:
+                start_offset = buff.tell()
+                shared_length = read_le_varint(buff, is_google_32bit=True)
+                non_shared_length = read_le_varint(buff, is_google_32bit=True)
+                value_length = read_le_varint(buff, is_google_32bit=True)
+
+                # sense check
+                if offset >= self._restart_array_offset:
+                    raise ValueError("Reading start of entry past the start of restart array")
+                if shared_length > len(key):
+                    raise ValueError("Shared key length is larger than the previous key")
+
+                key = key[:shared_length] + buff.read(non_shared_length)
+                value = buff.read(value_length)
+
+                yield RawBlockEntry(key, value, start_offset)
+
+
+class LdbFile:
+    """A leveldb table (.ldb) file."""
+    BLOCK_TRAILER_SIZE = 5
+    FOOTER_SIZE = 48
+    MAGIC = 0xdb4775248b80fb57
+
+    def __init__(self, file: pathlib.Path):
+        if not file.exists():
+            raise FileNotFoundError(file)
+
+        self.path = file
+        self.file_no = int(file.stem, 16)
+
+        self._f = file.open("rb")
+        self._f.seek(-LdbFile.FOOTER_SIZE, os.SEEK_END)
+
+        self._meta_index_handle = BlockHandle.from_stream(self._f)
+        self._index_handle = BlockHandle.from_stream(self._f)
+        self._f.seek(-8, os.SEEK_END)
+        magic, = struct.unpack("<Q", self._f.read(8))
+        if magic != LdbFile.MAGIC:
+            raise ValueError(f"Invalid magic number in {file}")
+
+        self._index = self._read_index()
+
+    def _read_block(self, handle: BlockHandle):
+        # block is the size in the blockhandle plus the trailer
+        # the trailer is 5 bytes long.
+        # idx  size  meaning
+        # 0    1     CompressionType (0 = none, 1 = snappy)
+        # 1    4     CRC32
+
+        self._f.seek(handle.offset)
+        raw_block = self._f.read(handle.length)
+        trailer = self._f.read(LdbFile.BLOCK_TRAILER_SIZE)
+
+        if len(raw_block) != handle.length or len(trailer) != LdbFile.BLOCK_TRAILER_SIZE:
+            raise ValueError(f"Could not read all of the block at offset {handle.offset} in file {self.path}")
+
+        is_compressed = trailer[0] != 0
+        if is_compressed:
+            with io.BytesIO(raw_block) as buff:
+                raw_block = ccl_simplesnappy.decompress(buff)
+
+        return Block(raw_block, is_compressed, self, handle.offset)
+
+    def _read_index(self) -> typing.Tuple[typing.Tuple[bytes, BlockHandle], ...]:
+        index_block = self._read_block(self._index_handle)
+        # key is earliest key, value is BlockHandle to that data block
+        return tuple((entry.key, BlockHandle.from_bytes(entry.value))
+                     for entry in index_block)
+
+    def __iter__(self) -> typing.Iterable[Record]:
+        """Iterate Records in this Table file"""
+        for block_key, handle in self._index:
+            block = self._read_block(handle)
+            for entry in block:
+                yield Record.ldb_record(
+                    entry.key, entry.value, self.path,
+                    block.offset if block.was_compressed else block.offset + entry.block_offset,
+                    block.was_compressed)
+
+    def close(self):
+        self._f.close()
+
+
+class LogEntryType(enum.IntEnum):
+    Zero = 0
+    Full = 1
+    First = 2
+    Middle = 3
+    Last = 4
+
+
+class LogFile:
+    """A levelDb log (.log) file"""
+    LOG_ENTRY_HEADER_SIZE = 7
+    LOG_BLOCK_SIZE = 32768
+
+    def __init__(self, file: pathlib.Path):
+        if not file.exists():
+            raise FileNotFoundError(file)
+
+        self.path = file
+        self.file_no = int(file.stem, 16)
+
+        self._f = file.open("rb")
+
+    def _get_raw_blocks(self) -> typing.Iterable[bytes]:
+        self._f.seek(0)
+
+        while chunk := self._f.read(LogFile.LOG_BLOCK_SIZE):
+            yield chunk
+
+    def _get_batches(self) -> typing.Iterable[typing.Tuple[int, bytes]]:
+        in_record = False
+        start_block_offset = 0
+        block = b""
+        for idx, chunk_ in enumerate(self._get_raw_blocks()):
+            with io.BytesIO(chunk_) as buff:
+                while buff.tell() < LogFile.LOG_BLOCK_SIZE - 6:
+                    header = buff.read(7)
+                    if len(header) < 7:
+                        break
+                    crc, length, block_type = struct.unpack("<IHB", header)
+
+                    if block_type == LogEntryType.Full:
+                        if in_record:
+                            raise ValueError(f"Full block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        in_record = False
+                        yield idx * LogFile.LOG_BLOCK_SIZE + buff.tell(), buff.read(length)
+                    elif block_type == LogEntryType.First:
+                        if in_record:
+                            raise ValueError(f"First block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        start_block_offset = idx * LogFile.LOG_BLOCK_SIZE + buff.tell()
+                        block = buff.read(length)
+                        in_record = True
+                    elif block_type == LogEntryType.Middle:
+                        if not in_record:
+                            raise ValueError(f"Middle block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                    elif block_type == LogEntryType.Last:
+                        if not in_record:
+                            raise ValueError(f"Last block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                        in_record = False
+                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                    else:
+                        raise ValueError()  # Cannot happen
+
+    def __iter__(self) -> typing.Iterable[Record]:
+        """Iterate Records in this Log file"""
+        for batch_offset, batch in self._get_batches():
+            # as per write_batch and write_batch_internal
+            # offset       length      description
+            # 0            8           (u?)int64 Sequence number
+            # 8            4           (u?)int32 Count - the log batch can contain multple entries
+            #
+            #         Then Count * the following:
+            #
+            # 12           1           ValueType (KeyState as far as this library is concerned)
+            # 13           1-4         VarInt32 length of key
+            # ...          ...         Key data
+            # ...          1-4         VarInt32 length of value
+            # ...          ...         Value data
+
+            with io.BytesIO(batch) as buff:  # it's just easier this way
+                header = buff.read(12)
+                seq, count = struct.unpack("<QI", header)
+
+                for i in range(count):
+                    start_offset = batch_offset + buff.tell()
+                    state = KeyState(buff.read(1)[0])
+                    key_length = read_le_varint(buff, is_google_32bit=True)
+                    key = buff.read(key_length)
+                    # print(key)
+                    if state != KeyState.Deleted:
+                        value_length = read_le_varint(buff, is_google_32bit=True)
+                        value = buff.read(value_length)
+                    else:
+                        value = b""
+
+                    yield Record.log_record(key, value, seq + i, state, self.path, start_offset)
+
+    def close(self):
+        self._f.close()
+
+
+class VersionEditTag(enum.IntEnum):
+    """
+    See: https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+    Comparator = 1,
+    LogNumber = 2,
+    NextFileNumber = 3,
+    LastSequence = 4,
+    CompactPointer = 5,
+    DeletedFile = 6,
+    NewFile = 7,
+    # 8 was used for large value refs
+    PrevLogNumber = 9
+
+
+@dataclasses.dataclass(frozen=True)
+class VersionEdit:
+    """
+    See:
+    https://github.com/google/leveldb/blob/master/db/version_edit.h
+    https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+    comparator: str = None
+    log_number: int = None
+    prev_log_number: int = None
+    last_sequence: int = None
+    next_file_number: int = None
+    compaction_pointers: typing.Tuple[typing.Any] = tuple()
+    deleted_files: typing.Tuple[typing.Any] = tuple()
+    new_files: typing.Tuple[typing.Any] = tuple()
+
+    @classmethod
+    def from_buffer(cls, buffer: bytes):
+        comparator = None
+        log_number = None
+        prev_log_number = None
+        last_sequence = None
+        next_file_number = None
+        compaction_pointers = []
+        deleted_files = []
+        new_files = []
+
+        compaction_pointer_nt = namedtuple("CompactionPointer", ["level", "pointer"])
+        deleted_file_nt = namedtuple("DeletedFile", ["level", "file_no"])
+        new_file_nt = namedtuple("NewFile", ["level", "file_no", "file_size", "smallest_key", "largest_key"])
+
+        with io.BytesIO(buffer) as b:
+            while b.tell() < len(buffer) - 1:
+                tag = read_le_varint(b, is_google_32bit=True)
+
+                if tag == VersionEditTag.Comparator:
+                    comparator = read_length_prefixed_blob(b).decode("utf-8")
+                elif tag == VersionEditTag.LogNumber:
+                    log_number = read_le_varint(b)
+                elif tag == VersionEditTag.PrevLogNumber:
+                    prev_log_number = read_le_varint(b)
+                elif tag == VersionEditTag.NextFileNumber:
+                    next_file_number = read_le_varint(b)
+                elif tag == VersionEditTag.LastSequence:
+                    last_sequence = read_le_varint(b)
+                elif tag == VersionEditTag.CompactPointer:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    compaction_pointer = read_length_prefixed_blob(b)
+                    compaction_pointers.append(compaction_pointer_nt(level, compaction_pointer))
+                elif tag == VersionEditTag.DeletedFile:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    file_no = read_le_varint(b)
+                    deleted_files.append(deleted_file_nt(level, file_no))
+                elif tag == VersionEditTag.NewFile:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    file_no = read_le_varint(b)
+                    file_size = read_le_varint(b)
+                    smallest = read_length_prefixed_blob(b)
+                    largest = read_length_prefixed_blob(b)
+                    new_files.append(new_file_nt(level, file_no, file_size, smallest, largest))
+
+        return cls(comparator, log_number, prev_log_number, last_sequence, next_file_number, tuple(compaction_pointers),
+            tuple(deleted_files), tuple(new_files))
+
+
+class ManifestFile:
+    """
+    Represents a manifest file which contains database metadata.
+    Manifest files are, at a high level, formatted like a log file in terms of the block and batch format,
+    but the data within the batches follow their own format.
+
+    Main use is to identify the level of files, use `file_to_level` property to look up levels based on file no.
+
+    See:
+    https://github.com/google/leveldb/blob/master/db/version_edit.h
+    https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+
+    MANIFEST_FILENAME_PATTERN = "MANIFEST-([0-9A-F]{6})"
+
+    def __init__(self, path: pathlib.Path):
+        if match := re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, path.name):
+            self.file_no = int(match.group(1))
+        else:
+            raise ValueError("Invalid name for Manifest")
+
+        self._f = path.open("rb")
+        self.path = path
+
+        self.file_to_level = {}
+        for edit in self:
+            if edit.new_files:
+                for nf in edit.new_files:
+                    self.file_to_level[nf.file_no] = nf.level
+
+        self.file_to_level = MappingProxyType(self.file_to_level)
+
+    def _get_raw_blocks(self) -> typing.Iterable[bytes]:
+        self._f.seek(0)
+
+        while chunk := self._f.read(LogFile.LOG_BLOCK_SIZE):
+            yield chunk
+
+    def _get_batches(self) -> typing.Iterable[typing.Tuple[int, bytes]]:
+        in_record = False
+        start_block_offset = 0
+        block = b""
+        for idx, chunk_ in enumerate(self._get_raw_blocks()):
+            with io.BytesIO(chunk_) as buff:
+                while buff.tell() < LogFile.LOG_BLOCK_SIZE - 6:
+                    header = buff.read(7)
+                    if len(header) < 7:
+                        break
+                    crc, length, block_type = struct.unpack("<IHB", header)
+
+                    if block_type == LogEntryType.Full:
+                        if in_record:
+                            raise ValueError(f"Full block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        in_record = False
+                        yield idx * LogFile.LOG_BLOCK_SIZE + buff.tell(), buff.read(length)
+                    elif block_type == LogEntryType.First:
+                        if in_record:
+                            raise ValueError(f"First block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        start_block_offset = idx * LogFile.LOG_BLOCK_SIZE + buff.tell()
+                        block = buff.read(length)
+                        in_record = True
+                    elif block_type == LogEntryType.Middle:
+                        if not in_record:
+                            raise ValueError(f"Middle block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                    elif block_type == LogEntryType.Last:
+                        if not in_record:
+                            raise ValueError(f"Last block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                        in_record = False
+                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                    else:
+                        raise ValueError()  # Cannot happen
+
+    def __iter__(self):
+        for batch_offset, batch in self._get_batches():
+            yield VersionEdit.from_buffer(batch)
+
+    def close(self):
+        self._f.close()
+
+
+class RawLevelDb:
+    DATA_FILE_PATTERN = r"[0-9]{6}\.(ldb|log)"
+
+    def __init__(self, in_dir: os.PathLike):
+
+        self._in_dir = pathlib.Path(in_dir)
+        if not self._in_dir.is_dir():
+            raise ValueError("in_dir is not a directory")
+
+        self._files = []
+        latest_manifest = (0, None)
+        for file in self._in_dir.iterdir():
+            if file.is_file() and re.match(RawLevelDb.DATA_FILE_PATTERN, file.name):
+                if file.suffix.lower() == ".log":
+                    self._files.append(LogFile(file))
+                elif file.suffix.lower() == ".ldb":
+                    self._files.append(LdbFile(file))
+            if file.is_file() and re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, file.name):
+                manifest_no = int(re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, file.name).group(1), 16)
+                if latest_manifest[0] < manifest_no:
+                    latest_manifest = (manifest_no, file)
+
+        self.manifest = ManifestFile(latest_manifest[1]) if latest_manifest[1] is not None else None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @property
+    def in_dir_path(self) -> pathlib.Path:
+        return self._in_dir
+
+    def iterate_records_raw(self, *, reverse=False) -> typing.Iterable[Record]:
+        for file_containing_records in sorted(self._files, reverse=reverse, key=lambda x: x.file_no):
+            yield from file_containing_records
+
+    def close(self):
+        for file in self._files:
+            file.close()
+        if self.manifest:
+            self.manifest.close()

--- a/pyhindsight/lib/ccl_chrome_indexeddb/ccl_simplesnappy.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/ccl_simplesnappy.py
@@ -1,0 +1,196 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import sys
+import struct
+import io
+import typing
+import enum
+
+__version__ = "0.1"
+__description__ = "Pure Python reimplementation of Google's Snappy decompression"
+__contact__ = "Alex Caithness"
+
+
+DEBUG = False
+
+
+def log(msg):
+    if DEBUG:
+        print(msg)
+
+
+class ElementType(enum.IntEnum):
+    """Run type in the compressed snappy data (literal data or offset to backreferenced data_"""
+    Literal = 0
+    CopyOneByte = 1
+    CopyTwoByte = 2
+    CopyFourByte = 3
+
+
+def _read_le_varint(stream: typing.BinaryIO) -> typing.Optional[typing.Tuple[int, bytes]]:
+    """Read varint from a stream.
+    If the read is successful: returns a tuple of the (unsigned) value and the raw bytes making up that varint,
+    otherwise returns None"""
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    while i < 10:  # 64 bit max possible?
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO) -> typing.Optional[int]:
+    """Convenience version of _read_le_varint that only returns the value or None"""
+    x = _read_le_varint(stream)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def read_uint16(stream: typing.BinaryIO) -> int:
+    """Reads a Uint16 from stream"""
+    return struct.unpack("<H", stream.read(2))[0]
+
+
+def read_uint24(stream: typing.BinaryIO) -> int:
+    """Reads a Uint24 from stream"""
+    return struct.unpack("<I", stream.read(3) + b"\x00")[0]
+
+
+def read_uint32(stream: typing.BinaryIO) -> int:
+    """Reads a Uint32 from stream"""
+    return struct.unpack("<I", stream.read(4))[0]
+
+
+def read_byte(stream: typing.BinaryIO) -> typing.Optional[int]:
+    """Reads a single byte from stream (or returns None if EOD is met)"""
+    x = stream.read(1)
+    if x:
+        return x[0]
+
+    return None
+
+
+def decompress(data: typing.BinaryIO) -> bytes:
+    """Decompresses the snappy compressed data stream"""
+    uncompressed_length = read_le_varint(data)
+    log(f"Uncompressed length: {uncompressed_length}")
+
+    out = io.BytesIO()
+
+    while True:
+        start_offset = data.tell()
+        log(f"Reading tag at offset {start_offset}")
+        type_byte = read_byte(data)
+        if type_byte is None:
+            break
+
+        log(f"Type Byte is {type_byte:02x}")
+
+        tag = type_byte & 0x03
+
+        log(f"Element Type is: {ElementType(tag)}")
+
+        if tag == ElementType.Literal:
+            if ((type_byte & 0xFC) >> 2) < 60:  # embedded in tag
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                log(f"Literal length is embedded in type byte and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 60:  # 8 bit
+                length = 1 + read_byte(data)
+                log(f"Literal length is 8bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 61:  # 16 bit
+                length = 1 + read_uint16(data)
+                log(f"Literal length is 16bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 62:  # 16 bit
+                length = 1 + read_uint24(data)
+                log(f"Literal length is 24bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 63:  # 16 bit
+                length = 1 + read_uint32(data)
+                log(f"Literal length is 32bit and is {length}")
+            else:
+                raise ValueError()  # cannot ever happen
+
+            literal_data = data.read(length)
+            if len(literal_data) < length:
+                raise ValueError("Couldn't read enough literal data")
+
+            out.write(literal_data)
+
+        else:
+            if tag == ElementType.CopyOneByte:
+                length = ((type_byte & 0x1C) >> 2) + 4
+                offset = ((type_byte & 0xE0) << 3) | read_byte(data)
+            elif tag == ElementType.CopyTwoByte:
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                offset = read_uint16(data)
+            elif tag == ElementType.CopyFourByte:
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                offset = read_uint32(data)
+            else:
+                raise ValueError()  # cannot ever happen
+
+            if offset == 0:
+                raise ValueError("Offset cannot be 0")
+
+            actual_offset = out.tell() - offset
+            log(f"Current Outstream Length: {out.tell()}")
+            log(f"Backreference length: {length}")
+            log(f"Backreference relative offset: {offset}")
+            log(f"Backreference absolute offset: {actual_offset}")
+
+            # have to read incrementally because you might have to read data that you've just written
+            # this is probably a really slow way of doing this.
+            for i in range(length):
+                out.write(out.getbuffer()[actual_offset + i: actual_offset + i + 1].tobytes())
+
+    result = out.getvalue()
+    if uncompressed_length != len(result):
+        raise ValueError("Wrong data length in uncompressed data")
+        # TODO: allow a partial / potentially bad result via a flag in the function call?
+
+    return result
+
+
+def main(path):
+    import pathlib
+    import hashlib
+    f = pathlib.Path(path).open("rb")
+    decompressed = decompress(f)
+    print(decompressed)
+    sha1 = hashlib.sha1()
+    sha1.update(decompressed)
+    print(sha1.hexdigest())
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/pyhindsight/lib/ccl_chrome_indexeddb/ccl_v8_value_deserializer.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/ccl_v8_value_deserializer.py
@@ -1,0 +1,595 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import sys
+import struct
+import datetime
+import types
+import typing
+import re
+
+__version__ = "0.1"
+__description__ = "Partial reimplementation of the V8 Javascript Object Serialization"
+__contact__ = "Alex Caithness"
+
+# TODO: We need to address cyclic references, which are permissible. Probably take the same approach as in ccl_bplist
+#  and subclass the collection types to resolve references JIT
+
+# See: https://github.com/v8/v8/blob/master/src/objects/value-serializer.cc
+
+__DEBUG = False
+
+
+def log(msg, debug_only=True):
+    if not debug_only or __DEBUG:
+        caller_name = sys._getframe(1).f_code.co_name
+        caller_line = sys._getframe(1).f_code.co_firstlineno
+        print(f"{caller_name} ({caller_line}):\t{msg}")
+
+
+def read_le_varint(stream: typing.BinaryIO) -> typing.Optional[typing.Tuple[int, bytes]]:
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    while i < 10:  # 64 bit max possible?
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+class _Undefined:
+    def __bool__(self):
+        return False
+
+    def __eq__(self, other):
+        if isinstance(other, _Undefined):
+            return True
+        return False
+
+
+class Constants:
+    # Constants
+    kLatestVersion = 13
+
+    # version:uint32_t (if at beginning of data, sets version > 0)
+    token_kVersion = b"\xFF"
+    # ignore
+    token_kPadding = b"\0"
+    # refTableSize:uint32_t (previously used for sanity checks; safe to ignore)
+    token_kVerifyObjectCount = b"?"
+    # Oddballs (no data).
+    token_kTheHole = b"-"
+    token_kUndefined = b"_"
+    token_kNull = b"0"
+    token_kTrue = b"T"
+    token_kFalse = b"F"
+    # Number represented as 32-bit integer, ZigZag-encoded
+    # (like sint32 in protobuf)
+    token_kInt32 = b"I"
+    # Number represented as 32-bit unsigned integer, varint-encoded
+    # (like uint32 in protobuf)
+    token_kUint32 = b"U"
+    # Number represented as a 64-bit double.
+    # Host byte order is used (N.B. this makes the format non-portable).
+    token_kDouble = b"N"
+    # BigInt. Bitfield:uint32_t, then raw digits storage.
+    token_kBigInt = b"Z"
+    # byteLength:uint32_t, then raw data
+    token_kUtf8String = b"S"
+    token_kOneByteString = b"\""
+    token_kTwoByteString = b"c"
+    # Reference to a serialized object. objectID:uint32_t
+    token_kObjectReference = b"^"
+    # Beginning of a JS object.
+    token_kBeginJSObject = b"o"
+    # End of a JS object. numProperties:uint32_t
+    token_kEndJSObject = b"{"
+    # Beginning of a sparse JS array. length:uint32_t
+    # Elements and properties are written as token_key/value pairs, like objects.
+    token_kBeginSparseJSArray = b"a"
+    # End of a sparse JS array. numProperties:uint32_t length:uint32_t
+    token_kEndSparseJSArray = b"@"
+    # Beginning of a dense JS array. length:uint32_t
+    # |length| elements, followed by properties as token_key/value pairs
+    token_kBeginDenseJSArray = b"A"
+    # End of a dense JS array. numProperties:uint32_t length:uint32_t
+    token_kEndDenseJSArray = b"$"
+    # Date. millisSinceEpoch:double
+    token_kDate = b"D"
+    # Boolean object. No data.
+    token_kTrueObject = b"y"
+    token_kFalseObject = b"x"
+    # Number object. value:double
+    token_kNumberObject = b"n"
+    # BigInt object. Bitfield:uint32_t, then raw digits storage.
+    token_kBigIntObject = b"z"
+    # String object, UTF-8 encoding. byteLength:uint32_t, then raw data.
+    token_kStringObject = b"s"
+    # Regular expression, UTF-8 encoding. byteLength:uint32_t, raw data
+    # flags:uint32_t.
+    token_kRegExp = b"R"
+    # Beginning of a JS map.
+    token_kBeginJSMap = b";"
+    # End of a JS map. length:uint32_t.
+    token_kEndJSMap = b":"
+    # Beginning of a JS set.
+    token_kBeginJSSet = b"'"
+    # End of a JS set. length:uint32_t.
+    token_kEndJSSet = b","
+    # Array buffer. byteLength:uint32_t, then raw data.
+    token_kArrayBuffer = b"B"
+    # Array buffer (transferred). transferID:uint32_t
+    token_kArrayBufferTransfer = b"t"
+    # View into an array buffer.
+    # subtag:ArrayBufferViewTag, byteOffset:uint32_t, byteLength:uint32_t
+    # For typed arrays, byteOffset and byteLength must be divisible by the size
+    # of the element.
+    # Note: token_kArrayBufferView is special, and should have an ArrayBuffer (or an
+    # ObjectReference to one) serialized just before it. This is a quirk arising
+    # from the previous stack-based implementation.
+    token_kArrayBufferView = b"V"
+    # Shared array buffer. transferID:uint32_t
+    token_kSharedArrayBuffer = b"u"
+    # A wasm module object transfer. next value is its index.
+    token_kWasmModuleTransfer = b"w"
+    # The delegate is responsible for processing all following data.
+    # This "escapes" to whatever wire format the delegate chooses.
+    token_kHostObject = b"\\"
+    # A transferred WebAssembly.Memory object. maximumPages:int32_t, then by
+    # SharedArrayBuffer tag and its data.
+    token_kWasmMemoryTransfer = b"m"
+    # A list of (subtag: ErrorTag, [subtag dependent data]). See ErrorTag for
+    # details.
+    token_kError = b"r"
+
+    # The following tags are reserved because they were in use in Chromium before
+    # the token_kHostObject tag was introduced in format version 13, at
+    #   v8           refs/heads/master@{#43466}
+    #   chromium/src refs/heads/master@{#453568}
+    #
+    # They must not be reused without a version check to prevent old values from
+    # starting to deserialize incorrectly. For simplicity, it's recommended to
+    # avoid them altogether.
+    #
+    # This is the set of tags that existed in SerializationTag.h at that time and
+    # still exist at the time of this writing (i.e., excluding those that were
+    # removed on the Chromium side because there should be no real user data
+    # containing them).
+    #
+    # It might be possible to also free up other tags which were never persisted
+    # (e.g. because they were used only for transfer) in the future.
+    token_kLegacyReservedMessagePort = b"M"
+    token_kLegacyReservedBlob = b"b"
+    token_kLegacyReservedBlobIndex = b"i"
+    token_kLegacyReservedFile = b"f"
+    token_kLegacyReservedFileIndex = b"e"
+    token_kLegacyReservedDOMFileSystem = b"d"
+    token_kLegacyReservedFileList = b"l"
+    token_kLegacyReservedFileListIndex = b"L"
+    token_kLegacyReservedImageData = b"#"
+    token_kLegacyReservedImageBitmap = b"g"
+    token_kLegacyReservedImageBitmapTransfer = b"G"
+    token_kLegacyReservedOffscreenCanvas = b"H"
+    token_kLegacyReservedCryptoKey = b"token_k"
+    token_kLegacyReservedRTCCertificate = b"token_k"
+
+
+class ArrayBufferViewTag:
+    tag_kInt8Array = "b"
+    tag_kUint8Array = "B"
+    tag_kUint8ClampedArray = "C"
+    tag_kInt16Array = "w"
+    tag_kUint16Array = "W"
+    tag_kInt32Array = "d"
+    tag_kUint32Array = "D"
+    tag_kFloat32Array = "f"
+    tag_kFloat64Array = "F"
+    tag_kBigInt64Array = "q"
+    tag_kBigUint64Array = "Q"
+    tag_kDataView = "?"
+
+    STRUCT_LOOKUP = types.MappingProxyType({
+        tag_kInt8Array: "b",
+        tag_kUint8Array: "B",
+        tag_kUint8ClampedArray: "B",
+        tag_kInt16Array: "h",
+        tag_kUint16Array: "H",
+        tag_kInt32Array: "i",
+        tag_kUint32Array: "I",
+        tag_kFloat32Array: "f",
+        tag_kFloat64Array: "d",
+        tag_kBigInt64Array: "q",
+        tag_kBigUint64Array: "Q",
+        tag_kDataView: "c"
+    })
+
+
+class Deserializer:
+    Undefined = _Undefined()
+
+    __ODDBALLS = {
+        Constants.token_kUndefined: Undefined,
+        Constants.token_kTheHole: Undefined,
+        Constants.token_kNull: None,
+        Constants.token_kTrue: True,
+        Constants.token_kFalse: False,
+    }
+
+    __WRAPPED_PRIMITIVES = {
+        Constants.token_kTrueObject,
+        Constants.token_kFalseObject,
+        Constants.token_kNumberObject,
+        Constants.token_kBigIntObject,
+        Constants.token_kStringObject
+    }
+
+    def __init__(self, stream: typing.BinaryIO, host_object_delegate: typing.Callable,
+                 *, is_little_endian=True, is_64bit=True):
+        self._f = stream
+        self._host_object_delegate = host_object_delegate
+        self._endian = "<" if is_little_endian else ">"
+        self._pointer_size = 8 if is_64bit else 4
+        self._next_id = 0
+        self._objects = []
+        self.version = self._read_header()
+
+    def _read_raw(self, length: int) -> bytes:
+        start = self._f.tell()
+        raw = self._f.read(length)
+        if len(raw) != length:
+            raise ValueError(f"Could not read all data at offset {start}; wanted {length}; got {len(raw)}")
+
+        return raw
+
+    def _read_le_varint(self) -> typing.Optional[typing.Tuple[int, bytes]]:
+        return read_le_varint(self._f)
+
+    def _read_zigzag(self) -> int:
+        unsigned = self._read_le_varint()[0]
+        if unsigned & 1:
+            return -(unsigned >> 1)
+        else:
+            return unsigned >> 1
+
+    def _read_double(self) -> float:
+        return struct.unpack(f"{self._endian}d", self._read_raw(8))[0]
+
+    # def _read_uint32(self) -> int:
+    #     return self._read_le_varint()
+
+    # def _read_uint64(self) -> int:
+    #     return self._read_le_varint()
+
+    def _read_bigint(self) -> int:
+        size_flag = self._read_le_varint()[0]
+        is_neg = size_flag & 0x01
+        size = size_flag >> 4
+        raw = self._read_raw(size * self._pointer_size)
+
+        value = int.from_bytes(raw, "big" if self._endian == ">" else "little", signed=False)
+        if is_neg:
+            value = -value
+
+        return value
+
+    def _read_utf8_string(self) -> str:
+        length = self._read_le_varint()[0]
+        return self._read_raw(length).decode("utf8")
+
+    def _read_one_byte_string(self) -> typing.AnyStr:
+        length = self._read_le_varint()[0]
+        # I think this can be used to store raw 8-bit data, so return ascii if we can, otherwise bytes
+        raw = self._read_raw(length)  # .decode("ascii")
+        try:
+            result = raw.decode("ascii")
+        except UnicodeDecodeError:
+            result = raw
+        return result
+
+    def _read_two_byte_string(self) -> str:
+        length = self._read_le_varint()[0]
+        return self._read_raw(length).decode("utf-16-le")  # le?
+
+    def _read_string(self) -> str:
+        if self.version < 12:
+            return self._read_utf8_string()
+
+        value = self._read_object()
+        assert isinstance(value, str)
+
+        return value
+
+    def _read_object_by_reference(self) -> typing.Any:
+        ref_id = self._read_le_varint()[0]
+        return self._objects[ref_id]
+
+    def _read_tag(self) -> bytes:
+        while True:
+            t = self._f.read(1)
+            if t != Constants.token_kPadding:
+                return t
+
+    def _peek_tag(self) -> bytes:
+        start = self._f.tell()
+        tag = self._read_tag()
+        self._f.seek(start, 0)
+        return tag
+
+    def _read_date(self) -> datetime.datetime:
+        x = self._read_double()
+        result = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=x)
+        self._objects.append(result)
+        return result
+
+    def _read_js_regex(self) -> typing.Pattern:
+        log(f"Reading js regex properties at {self._f.tell()}")
+        pattern = self._read_string()
+        flags = self._read_le_varint()
+
+        # TODO: Flags?
+        regex = re.compile(pattern)
+        self._objects.append(regex)
+        return regex
+
+    def _read_js_object_properties(self, end_tag) -> typing.Iterable[typing.Tuple[typing.Any, typing.Any]]:
+        log(f"Reading object properties at {self._f.tell()} with end tag: {end_tag}")
+        while True:
+            if self._peek_tag() == end_tag:
+                log(f"Object end at offset {self._f.tell()}")
+                break
+            key = self._read_object()
+            value = self._read_object()
+
+            yield key, value
+
+        assert self._read_tag() == end_tag
+
+    def _read_js_object(self) -> dict:
+        log(f"Reading js object properties at {self._f.tell()}")
+        result = {}
+        self._objects.append(result)
+        for key, value in self._read_js_object_properties(Constants.token_kEndJSObject):
+            result[key] = value
+        # while True:
+        #     if self._peek_tag() == end_tag:
+        #         log(f"Object end at offset {self._f.tell()}")
+        #         break
+        #     key = self._read_object()
+        #     value = self._read_object()
+        #     result[key] = value
+        #
+        # assert self._read_tag() == end_tag
+        property_count = self._read_le_varint()[0]
+        log(f"Actual property count: {len(result)}; stated property count: {property_count}")
+        if len(result) != property_count:
+            raise ValueError("Property count mismatch")
+
+        return result
+
+    def _read_js_sparse_array(self) -> list:
+        log(f"Reading js sparse array properties at {self._f.tell()}")
+        # TODO: implement a sparse list so that this isn't so horribly inefficient
+        length = self._read_le_varint()[0]
+        result = [None for _ in range(length)]
+        self._objects.append(result)
+
+        sparse_object = self._read_js_object_properties(Constants.token_kEndSparseJSArray)
+        prop_count = 0
+        for key, value in sparse_object:
+            i = int(key)
+            result[i] = value
+            prop_count += 1
+        expected_num_properties = self._read_le_varint()[0]
+
+        log(f"Actual property count: {prop_count}; stated property count: {expected_num_properties}")
+        if prop_count != expected_num_properties:
+            raise ValueError("Property count mismatch")
+
+        expected_length = self._read_le_varint()[0]  # TODO: should this be checked?
+
+        return result
+
+    def _read_js_dense_array(self) -> list:
+        log(f"Reading js dense array properties at {self._f.tell()}")
+        length = self._read_le_varint()[0]
+        result = [None for _ in range(length)]
+        self._objects.append(result)
+
+        for i in range(length):
+            result[i] = self._read_object()
+
+        # And then there's a sparse bit maybe?
+        sparse_object = self._read_js_object_properties(Constants.token_kEndDenseJSArray)
+        prop_count = 0
+        for key, value in sparse_object:
+            i = int(key)
+            result[i] = value
+            prop_count += 1
+
+        expected_num_properties = self._read_le_varint()[0]
+
+        log(f"Actual property count: {prop_count}; stated property count: {expected_num_properties}")
+        if prop_count != expected_num_properties:
+            raise ValueError("Property count mismatch")
+
+        expected_length = self._read_le_varint()[0]  # TODO: should this be checked?
+
+        return result
+
+    def _read_js_map(self) -> dict:
+        log(f"Reading js map at {self._f.tell()}")
+        result = {}
+        self._objects.append(result)
+        while True:
+            if self._peek_tag() == Constants.token_kEndJSMap:
+                log(f"End of map at {self._f.tell()}")
+                break
+
+            key = self._read_object()
+            value = self._read_object()
+            result[key] = value
+
+        assert self._read_tag() == Constants.token_kEndJSMap
+
+        expected_length = self._read_le_varint()[0]
+        log(f"Actual map item count: {len(result) * 2}; stated map item count: {expected_length}")
+        if expected_length != len(result) * 2:
+            raise ValueError("Map count mismatch")
+
+        return result
+
+    def _read_js_set(self) -> set:
+        log(f"Reading js set properties at {self._f.tell()}")
+        result = set()
+        self._objects.append(result)
+
+        while True:
+            if self._peek_tag() == Constants.token_kEndJSSet:
+                log(f"End of set at {self._f.tell()}")
+                break
+
+            result.add(self._read_object())
+
+        assert self._read_tag() == Constants.token_kEndJSSet
+
+        expected_length = self._read_le_varint()[0]
+        log(f"Actual set item count: {len(result)}; stated set item count: {expected_length}")
+        if expected_length != len(result):
+            raise ValueError("Set count mismatch")
+
+        return result
+
+    def _read_js_arraybuffer(self) -> bytes:
+        length = self._read_le_varint()[0]
+        raw = self._read_raw(length)
+        self._objects.append(raw)
+
+        return raw
+
+    def _wrap_js_array_buffer_view(self, raw: bytes) -> tuple:
+        if not isinstance(raw, bytes):
+            raise TypeError("Only bytes should be passed to be wrapped in a buffer view")
+
+        log(f"Wrapping in ArrayBufferView at offset {self._f.tell()}")
+
+        tag = chr(self._read_le_varint()[0])
+        byte_offset = self._read_le_varint()[0]
+        byte_length = self._read_le_varint()[0]
+
+        if byte_offset + byte_length > len(raw):
+            raise ValueError("Not enough data in the raw data to hold the defined data")
+
+        log(f"ArrayBufferView: tag: {tag}; byte_offset: {byte_offset}; byte_length: {byte_length}")
+
+        fmt = ArrayBufferViewTag.STRUCT_LOOKUP[tag]
+        element_length = struct.calcsize(fmt)
+        if byte_length % element_length != 0:
+            raise ValueError(f"ArrayBufferView doesn't fit nicely: byte_length: {byte_length}; "
+                             f"element_length: {element_length}")
+
+        element_count = byte_length // element_length
+
+        return struct.unpack(f"{self._endian}{element_count}{fmt}", raw[byte_offset: byte_offset + byte_length])
+
+    def _read_host_object(self) -> typing.Any:
+        result = self._host_object_delegate(self._f)
+        self._objects.append(result)
+        return result
+
+    def _not_implemented(self):
+        raise NotImplementedError("Todo")
+
+    def _read_object_internal(self) -> typing.Tuple[bytes, typing.Any]:
+        tag = self._read_tag()
+
+        log(f"Offset: {self._f.tell()}; Tag: {tag}")
+
+        if tag in Deserializer.__ODDBALLS:
+            return tag, Deserializer.__ODDBALLS[tag]
+
+        func = {
+            Constants.token_kTrueObject: lambda: Deserializer.__ODDBALLS[Constants.token_kTrue],
+            Constants.token_kFalseObject: lambda: Deserializer.__ODDBALLS[Constants.token_kFalse],
+            Constants.token_kNumberObject: self._read_double,
+            Constants.token_kUint32: self._read_le_varint,
+            Constants.token_kInt32: self._read_zigzag,
+            Constants.token_kDouble: self._read_double,
+            Constants.token_kDate: self._read_date,
+            Constants.token_kBigInt: self._read_bigint,
+            Constants.token_kBigIntObject: self._read_bigint,
+            Constants.token_kUtf8String: self._read_utf8_string,
+            Constants.token_kOneByteString: self._read_one_byte_string,
+            Constants.token_kTwoByteString: self._read_two_byte_string,
+            Constants.token_kStringObject: self._read_string,
+            Constants.token_kRegExp: self._read_js_regex,
+            Constants.token_kObjectReference: self._read_object_by_reference,
+            Constants.token_kBeginJSObject: self._read_js_object,
+            Constants.token_kBeginSparseJSArray: self._read_js_sparse_array,
+            Constants.token_kBeginDenseJSArray: self._read_js_dense_array,
+            Constants.token_kBeginJSMap: self._read_js_map,
+            Constants.token_kBeginJSSet: self._read_js_set,
+            Constants.token_kArrayBuffer: self._read_js_arraybuffer,
+            Constants.token_kSharedArrayBuffer: self._not_implemented,  # and probably never, as it can't be pulled from the data I think?
+            Constants.token_kArrayBufferTransfer: self._not_implemented,
+            Constants.token_kError: self._not_implemented,
+            Constants.token_kWasmModuleTransfer: self._not_implemented,
+            Constants.token_kWasmMemoryTransfer: self._not_implemented,
+            Constants.token_kHostObject: self._read_host_object,
+        }.get(tag)
+
+        if func is None:
+            raise ValueError(f"Unknown tag {tag}")
+
+        value = func()
+
+        if tag in Deserializer.__WRAPPED_PRIMITIVES:
+            self._objects.append(value)
+
+        return tag, value
+
+    def _read_object(self) -> typing.Any:
+        log(f"Read object at offset: {self._f.tell()}")
+        tag, o = self._read_object_internal()
+
+        if self._peek_tag() == Constants.token_kArrayBufferView:
+            assert self._read_tag() == Constants.token_kArrayBufferView
+            o = self._wrap_js_array_buffer_view(o)
+
+        return o
+
+    def _read_header(self) -> int:
+        tag = self._read_tag()
+        if tag != Constants.token_kVersion:
+            raise ValueError("Didn't get version tag in the header")
+        version = self._read_le_varint()[0]
+        return version
+
+    def read(self) -> typing.Any:
+        return self._read_object()

--- a/pyhindsight/lib/ccl_chrome_indexeddb/dump_indexeddb_details.py
+++ b/pyhindsight/lib/ccl_chrome_indexeddb/dump_indexeddb_details.py
@@ -1,0 +1,37 @@
+import sys
+import pathlib
+import ccl_chromium_indexeddb
+
+
+def main(args):
+    ldb_path = pathlib.Path(args[0])
+    wrapper = ccl_chromium_indexeddb.WrappedIndexDB(ldb_path)
+
+    for db_info in wrapper.database_ids:
+        db = wrapper[db_info.dbid_no]
+        print("------Database------")
+        print(f"db_number={db.db_number}; name={db.name}; origin={db.origin}")
+        print()
+        print("\t---Object Stores---")
+        for obj_store_name in db.object_store_names:
+            obj_store = db[obj_store_name]
+            print(f"\tobject_store_id={obj_store.object_store_id}; name={obj_store.name}")
+            try:
+                one_record = next(obj_store.iterate_records())
+            except StopIteration:
+                one_record = None
+            if one_record is not None:
+                print("\tExample record:")
+                print(f"\tkey: {one_record.key}")
+                print(f"\tvalue: {one_record.value}")
+            else:
+                print("\tNo records")
+            print()
+        print()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f"USAGE: {pathlib.Path(sys.argv[0]).name} <ldb dir path>")
+        exit(1)
+    main(sys.argv[1:])

--- a/pyhindsight/utils.py
+++ b/pyhindsight/utils.py
@@ -172,11 +172,10 @@ def get_ldb_records(ldb_path, prefix=''):
 
         if cleaned_record['key'].startswith(prefix):
             cleaned_record['key'] = cleaned_record['key'][len(prefix):]
+            cleaned_record['state'] = cleaned_record['state'].name
+            cleaned_record['file_type'] = cleaned_record['file_type'].name
 
-        cleaned_record['state'] = cleaned_record['state'].name
-        cleaned_record['file_type'] = cleaned_record['file_type'].name
-
-        cleaned_records.append(cleaned_record)
+            cleaned_records.append(cleaned_record)
 
     return cleaned_records
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-plyvel>=1.2
 keyring>=21.2.1
 pytz>=2020.1
 pycryptodome>=3.9.7
 pycryptodomex>=3.9.7
 xlsxwriter>=1.2.9
 bottle>=0.12.18
+setuptools~=51.0.0
+puremagic~=1.10
+argparse~=1.4.0


### PR DESCRIPTION
Switch from plyvel to ccl_leveldb for reading LevelDBs (requires adding ccl_chrome_indexeddb code under pyhindsight/lib). This removes the install challenges that go with plyvel and adds **recovery of deleted records**.

Reworked existing LevelDB parsing (of LocalStorage and FileSystem items) to use ccl_leveldb and incorporate deleted records where appropriate. 

Add more information about local files in FileSystem: if they exist, file size, and file "magic" info (using puremagic). 
