### PR TITLE
Add check to ensure duration values in Media History are plausible

### DIFF
--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -374,7 +374,9 @@ class Chrome(WebBrowser):
                 for row in cursor:
                     duration = None
                     if row.get('duration_ms'):
-                        duration = str(datetime.timedelta(milliseconds=row.get('duration_ms')))[:-3]
+                        # Check is duration value is reasonable; some have been equivalent of 300 million years
+                        if row.get('duration_ms') < 2600000:
+                            duration = str(datetime.timedelta(milliseconds=row.get('duration_ms')))[:-3]
 
                     position = None
                     if row.get('position_ms'):


### PR DESCRIPTION
 Python can't convert super large ints - some values were set to millions of years.