### PR TITLE
Timestamp sorting tz bug

### DIFF
--- a/hindsight.py
+++ b/hindsight.py
@@ -195,7 +195,7 @@ def main():
     # Hindsight version info
     log.info(
         '\n' + '#' * 80 +
-        f'\n###    Hindsight v{pyhindsight.__version__} (https://github.com/obsidianforensics/hindsight)    ###\n' +
+        f'\n##   Hindsight v{pyhindsight.__version__} (https://github.com/obsidianforensics/hindsight)   ##\n' +
         '#' * 80)
 
     # Analysis start time

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -653,7 +653,8 @@ class Chrome(WebBrowser):
 
                     # If the cookie was created and accessed at the same time (only used once), or if the last accessed
                     # time is 0 (happens on iOS), don't create an accessed row
-                    if new_row.creation_utc != new_row.last_access_utc and accessed_row.last_access_utc != utils.to_datetime(0, self.timezone):
+                    if new_row.creation_utc != new_row.last_access_utc and \
+                            accessed_row.last_access_utc != utils.to_datetime(0, self.timezone):
                         accessed_row.row_type = 'cookie (accessed)'
                         accessed_row.timestamp = accessed_row.last_access_utc
                         results.append(accessed_row)


### PR DESCRIPTION
Add parsing of Epoch microseconds to to_datetime(); some (synced?) values use this timestamp format. When parsing some of these values as very large epoch second timestamps, it was too large for datetime to convert. A separate bug in the failback parsing caused a timezone-naive timestamp to be created, which led to the sorting issue.