### PR TITLE
Correct inconsistent use of quotation marks in metadata attribute access in webbrowser.py

### DIFF
--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -193,7 +193,7 @@ class WebBrowser(object):
             if not self.metadata:
                 return f"{len(self.data)} bytes"
 
-            return f"{(self.metadata.get_attribute("content-type") or ["not specified"])[0]} ({len(self.data)} bytes)"
+            return f"{(self.metadata.get_attribute('content-type') or ['not specified'])[0]} ({len(self.data)} bytes)"
 
         def stringify_http_headers(self):
             headers = {}


### PR DESCRIPTION
Fixed an error from a recent change