### PR TITLE
Regexp fix Update hindsight_gui.py

### DIFF
--- a/hindsight_gui.py
+++ b/hindsight_gui.py
@@ -108,7 +108,7 @@ def get_plugins_info():
 
 
 # Static Routes
-@bottle.get('/static/<filename:re:.*\.(png|css|ico|svg|json|eot|svg|ttf|woff|woff2|js)>')
+@bottle.get(r'/static/<filename:re:.*\.(png|css|ico|svg|json|eot|svg|ttf|woff|woff2|js)>')
 def images(filename):
     return bottle.static_file(filename, root=STATIC_PATH)
 


### PR DESCRIPTION
I was getting this error In rexexp

SyntaxWarning: invalid escape sequence '\.'
  @bottle.get('/static/<filename:re:.*\.(png|css|ico|svg|json|eot|svg|ttf|woff|woff2|js)>')