### PR TITLE
Add parsing of multiple databases related to Extensions

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -689,6 +689,10 @@ class AnalysisSession(object):
         blue_field_format = workbook.add_format({'font_color': 'blue', 'align': 'left'})
         blue_value_format = workbook.add_format({'font_color': 'blue', 'align': 'left'})
 
+        ################################
+        # Timeline worksheet
+        ################################
+
         # Title bar
         w.merge_range('A1:H1', 'Hindsight Internet History Forensics (v%s)' % __version__, title_header_format)
         w.merge_range('I1:O1', 'URL Specific', center_header_format)
@@ -896,6 +900,9 @@ class AnalysisSession(object):
         w.autofilter(1, 0, row_number, 20)  # Add autofilter
         w.filter_column('B', 'Timestamp > 1970-01-02')
 
+        ##############################
+        # Storage worksheet
+        ##############################
         s = workbook.add_worksheet('Storage')
         # Title bar
         s.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
@@ -998,59 +1005,60 @@ class AnalysisSession(object):
         s.freeze_panes(2, 0)  # Freeze top row
         s.autofilter(1, 0, row_number, 12)  # Add autofilter
 
-        e = workbook.add_worksheet('Extension Data')
+        #########################################
+        # Extension Data worksheet
+        #########################################
+        ext = workbook.add_worksheet('Extension Data')
         # Title bar
-        e.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
-        e.merge_range('H1:K1', 'Backing Database Specific', center_header_format)
-        e.merge_range('L1:N1', 'FileSystem Specific', center_header_format)
+        ext.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
+        ext.merge_range('H1:L1', 'Backing LevelDB Specific', center_header_format)
 
         # Write column headers
-        e.write(1, 0, 'Type', header_format)
-        e.write(1, 1, 'Origin', header_format)
-        e.write(1, 2, 'Key', header_format)
-        e.write(1, 3, 'Value', header_format)
-        e.write(1, 4, f'Modification Time ({self.timezone})', header_format)
-        e.write(1, 5, 'Interpretation', header_format)
-        e.write(1, 6, 'Profile', header_format)
-        e.write(1, 7, 'Source Path', header_format)
-        e.write(1, 8, 'Database', header_format)
-        e.write(1, 9, 'Sequence', header_format)
-        e.write(1, 10, 'State', header_format)
-        e.write(1, 11, 'File Exists?', header_format)
-        e.write(1, 12, 'File Size (bytes)', header_format)
-        e.write(1, 13, 'File Type (Confidence %)', header_format)
+        ext.write(1, 0, 'Type', header_format)
+        ext.write(1, 1, 'Extension ID', header_format)
+        ext.write(1, 2, 'Extension Name', header_format)
+        ext.write(1, 3, 'Key', header_format)
+        ext.write(1, 4, 'Value', header_format)
+        ext.write(1, 5, 'Interpretation', header_format)
+        ext.write(1, 6, 'Profile', header_format)
+        ext.write(1, 7, 'Source Path', header_format)
+        ext.write(1, 8, 'Offset', header_format)
+        ext.write(1, 9, 'Sequence', header_format)
+        ext.write(1, 10, 'State', header_format)
+        ext.write(1, 11, 'Was Compressed', header_format)
 
         # Set column widths
-        e.set_column('A:A', 16)  # Type
-        e.set_column('B:B', 30)  # Origin
-        e.set_column('C:C', 35)  # Key
-        e.set_column('D:D', 60)  # Value
-        e.set_column('E:E', 16)  # Mod Time
-        e.set_column('F:F', 50)  # Interpretation
-        e.set_column('G:G', 50)  # Profile
-        e.set_column('H:H', 50)  # Source Path
-        e.set_column('I:I', 16)  # Database
-        e.set_column('J:J', 8)   # Seq
-        e.set_column('K:K', 8)   # State
-        e.set_column('L:L', 8)   # Exists
-        e.set_column('M:M', 16)  # Size
-        e.set_column('N:N', 25)  # Type
+        ext.set_column('A:A', 16)  # Type
+        ext.set_column('B:B', 30)  # ID
+        ext.set_column('C:C', 30)  # Name
+        ext.set_column('D:D', 35)  # Key
+        ext.set_column('E:E', 70)  # Value
+        ext.set_column('F:F', 40)  # Interpretation
+        ext.set_column('G:G', 50)  # Profile
+        ext.set_column('H:H', 50)  # Source Path
+        ext.set_column('I:I', 12)  # Offset
+        ext.set_column('J:J', 8)   # Seq
+        ext.set_column('K:K', 8)   # State
+        ext.set_column('L:L', 8)   # Was Compressed
+
 
         # Start at the row after the headers, and begin writing out the items in parsed_artifacts
         row_number = 2
         for item in self.parsed_extension_data:
             try:
                 if item.row_type:
-                    e.write_string(row_number, 0, item.row_type, black_type_format)
-                    e.write_string(row_number, 1, item.origin, black_url_format)
-                    e.write_string(row_number, 2, item.key, black_field_format)
-                    e.write_string(row_number, 3, item.value, black_value_format)
-                    e.write(row_number, 5, item.interpretation, black_value_format)
-                    e.write(row_number, 6, item.profile, black_value_format)
-                    e.write(row_number, 7, item.source_path, black_value_format)
-                    # e.write(row_number, 8, item.database, black_value_format)
-                    e.write_number(row_number, 9, item.seq, black_value_format)
-                    e.write_string(row_number, 10, item.state, black_value_format)
+                    ext.write_string(row_number, 0, item.row_type, black_type_format)
+                    ext.write(row_number, 1, item.extension_name, black_url_format)
+                    ext.write_string(row_number, 2, item.extension_id, black_url_format)
+                    ext.write_string(row_number, 3, item.key, black_field_format)
+                    ext.write_string(row_number, 4, item.value, black_value_format)
+                    ext.write(row_number, 5, item.interpretation, black_value_format)
+                    ext.write(row_number, 6, item.profile, black_value_format)
+                    ext.write(row_number, 7, item.source_path, black_value_format)
+                    ext.write(row_number, 8, item.offset, black_value_format)
+                    ext.write_number(row_number, 9, item.seq, black_value_format)
+                    ext.write_string(row_number, 10, item.state, black_value_format)
+                    ext.write(row_number, 11, item.was_compressed, black_flag_format)
 
             except Exception as e:
                 log.error(f'Failed to write row to XLSX: {e}')
@@ -1058,8 +1066,8 @@ class AnalysisSession(object):
             row_number += 1
 
         # Formatting
-        e.freeze_panes(2, 0)  # Freeze top row
-        e.autofilter(1, 0, row_number, 12)  # Add autofilter
+        ext.freeze_panes(2, 0)  # Freeze top row
+        ext.autofilter(1, 0, row_number, 12)  # Add autofilter
 
         for item in self.__dict__:
             try:

--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -302,6 +302,7 @@ class AnalysisSession(object):
         self.artifacts_display = artifacts_display
         self.artifacts_counts = artifacts_counts
         self.parsed_storage = parsed_storage
+        self.parsed_extension_data = []
         self.plugin_descriptions = plugin_descriptions
         self.selected_plugins = selected_plugins
         self.plugin_results = plugin_results
@@ -527,6 +528,7 @@ class AnalysisSession(object):
                 browser_analysis.process()
                 self.parsed_artifacts.extend(browser_analysis.parsed_artifacts)
                 self.parsed_storage.extend(browser_analysis.parsed_storage)
+                self.parsed_extension_data.extend(browser_analysis.parsed_extension_data)
                 self.artifacts_counts = self.sum_dict_counts(self.artifacts_counts, browser_analysis.artifacts_counts)
                 self.artifacts_display = browser_analysis.artifacts_display
                 self.version.extend(browser_analysis.version)
@@ -975,6 +977,18 @@ class AnalysisSession(object):
                     s.write_number(row_number, 9, item.seq, black_value_format)
                     s.write_string(row_number, 10, item.state, black_value_format)
 
+                else:
+                    s.write_string(row_number, 0, item.row_type, black_type_format)
+                    s.write_string(row_number, 1, item.origin, black_url_format)
+                    s.write_string(row_number, 2, item.key, black_field_format)
+                    s.write_string(row_number, 3, item.value, black_value_format)
+                    s.write(row_number, 5, item.interpretation, black_value_format)
+                    s.write(row_number, 6, item.profile, black_value_format)
+                    s.write(row_number, 7, item.source_path, black_value_format)
+                    # s.write(row_number, 8, item.database, black_value_format)
+                    s.write_number(row_number, 9, item.seq, black_value_format)
+                    s.write_string(row_number, 10, item.state, black_value_format)
+
             except Exception as e:
                 log.error(f'Failed to write row to XLSX: {e}')
 
@@ -983,6 +997,69 @@ class AnalysisSession(object):
         # Formatting
         s.freeze_panes(2, 0)  # Freeze top row
         s.autofilter(1, 0, row_number, 12)  # Add autofilter
+
+        e = workbook.add_worksheet('Extension Data')
+        # Title bar
+        e.merge_range('A1:G1', f'Hindsight Internet History Forensics (v{__version__})', title_header_format)
+        e.merge_range('H1:K1', 'Backing Database Specific', center_header_format)
+        e.merge_range('L1:N1', 'FileSystem Specific', center_header_format)
+
+        # Write column headers
+        e.write(1, 0, 'Type', header_format)
+        e.write(1, 1, 'Origin', header_format)
+        e.write(1, 2, 'Key', header_format)
+        e.write(1, 3, 'Value', header_format)
+        e.write(1, 4, f'Modification Time ({self.timezone})', header_format)
+        e.write(1, 5, 'Interpretation', header_format)
+        e.write(1, 6, 'Profile', header_format)
+        e.write(1, 7, 'Source Path', header_format)
+        e.write(1, 8, 'Database', header_format)
+        e.write(1, 9, 'Sequence', header_format)
+        e.write(1, 10, 'State', header_format)
+        e.write(1, 11, 'File Exists?', header_format)
+        e.write(1, 12, 'File Size (bytes)', header_format)
+        e.write(1, 13, 'File Type (Confidence %)', header_format)
+
+        # Set column widths
+        e.set_column('A:A', 16)  # Type
+        e.set_column('B:B', 30)  # Origin
+        e.set_column('C:C', 35)  # Key
+        e.set_column('D:D', 60)  # Value
+        e.set_column('E:E', 16)  # Mod Time
+        e.set_column('F:F', 50)  # Interpretation
+        e.set_column('G:G', 50)  # Profile
+        e.set_column('H:H', 50)  # Source Path
+        e.set_column('I:I', 16)  # Database
+        e.set_column('J:J', 8)   # Seq
+        e.set_column('K:K', 8)   # State
+        e.set_column('L:L', 8)   # Exists
+        e.set_column('M:M', 16)  # Size
+        e.set_column('N:N', 25)  # Type
+
+        # Start at the row after the headers, and begin writing out the items in parsed_artifacts
+        row_number = 2
+        for item in self.parsed_extension_data:
+            try:
+                if item.row_type:
+                    e.write_string(row_number, 0, item.row_type, black_type_format)
+                    e.write_string(row_number, 1, item.origin, black_url_format)
+                    e.write_string(row_number, 2, item.key, black_field_format)
+                    e.write_string(row_number, 3, item.value, black_value_format)
+                    e.write(row_number, 5, item.interpretation, black_value_format)
+                    e.write(row_number, 6, item.profile, black_value_format)
+                    e.write(row_number, 7, item.source_path, black_value_format)
+                    # e.write(row_number, 8, item.database, black_value_format)
+                    e.write_number(row_number, 9, item.seq, black_value_format)
+                    e.write_string(row_number, 10, item.state, black_value_format)
+
+            except Exception as e:
+                log.error(f'Failed to write row to XLSX: {e}')
+
+            row_number += 1
+
+        # Formatting
+        e.freeze_panes(2, 0)  # Freeze top row
+        e.autofilter(1, 0, row_number, 12)  # Add autofilter
 
         for item in self.__dict__:
             try:

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -41,27 +41,21 @@ log = logging.getLogger(__name__)
 
 class Chrome(WebBrowser):
     def __init__(self, profile_path, browser_name=None, cache_path=None, version=None, timezone=None,
-                 parsed_artifacts=None, parsed_storage=None, storage=None, installed_extensions=None,
-                 artifacts_counts=None, artifacts_display=None, available_decrypts=None, preferences=None,
-                 no_copy=None, temp_dir=None, origin_hashes=None, hsts_hashes=None):
+                 storage=None, available_decrypts=None, no_copy=None, temp_dir=None):
         WebBrowser.__init__(
             self, profile_path, browser_name=browser_name, cache_path=cache_path, version=version, timezone=timezone,
-            parsed_artifacts=parsed_artifacts, parsed_storage=parsed_storage, artifacts_counts=artifacts_counts,
-            artifacts_display=artifacts_display, preferences=preferences, no_copy=no_copy, temp_dir=temp_dir,
-            origin_hashes=origin_hashes)
+            no_copy=no_copy, temp_dir=temp_dir)
         self.profile_path = profile_path
         self.browser_name = "Chrome"
         self.cache_path = cache_path
         self.timezone = timezone
-        self.installed_extensions = installed_extensions
+        self.installed_extensions = []
         self.cached_key = None
         self.available_decrypts = available_decrypts
         self.storage = storage
-        self.preferences = preferences
         self.no_copy = no_copy
         self.temp_dir = temp_dir
-        self.origin_hashes = origin_hashes
-        self.hsts_hashes = hsts_hashes
+        self.hsts_hashes = {}
 
         if self.version is None:
             self.version = []
@@ -69,32 +63,13 @@ class Chrome(WebBrowser):
         if self.structure is None:
             self.structure = {}
 
-        if self.parsed_artifacts is None:
-            self.parsed_artifacts = []
-
-        if self.parsed_storage is None:
-            self.parsed_storage = []
-
-        if self.installed_extensions is None:
-            self.installed_extensions = []
 
         if self.preferences is None:
             self.preferences = []
 
-        if self.origin_hashes is None:
-            self.origin_hashes = {}
-
-        if self.hsts_hashes is None:
-            self.hsts_hashes = {}
-
-        if self.artifacts_counts is None:
-            self.artifacts_counts = {}
 
         if self.storage is None:
             self.storage = {}
-
-        if self.artifacts_display is None:
-            self.artifacts_display = {}
 
         if self.available_decrypts is None:
             self.available_decrypts = {'windows': 0, 'mac': 0, 'linux': 0}

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -12,8 +12,7 @@ log = logging.getLogger(__name__)
 class WebBrowser(object):
     def __init__(
             self, profile_path, browser_name, cache_path=None, version=None, display_version=None,
-            timezone=None, structure=None, parsed_artifacts=None, parsed_storage=None, artifacts_counts=None,
-            artifacts_display=None, preferences=None, no_copy=None, temp_dir=None, origin_hashes=None):
+            timezone=None, structure=None, no_copy=None, temp_dir=None):
         self.profile_path = profile_path
         self.browser_name = browser_name
         self.cache_path = cache_path
@@ -21,35 +20,18 @@ class WebBrowser(object):
         self.display_version = display_version
         self.timezone = timezone
         self.structure = structure
-        self.parsed_artifacts = parsed_artifacts
-        self.parsed_storage = parsed_storage
-        self.artifacts_counts = artifacts_counts
-        self.artifacts_display = artifacts_display
-        self.preferences = preferences
+        self.parsed_artifacts = []
+        self.parsed_storage = []
+        self.parsed_extension_data = []
+        self.artifacts_counts = {}
+        self.artifacts_display = {}
+        self.preferences = []
         self.no_copy = no_copy
         self.temp_dir = temp_dir
-        self.origin_hashes = origin_hashes
+        self.origin_hashes = {}
 
         if self.version is None:
             self.version = []
-
-        if self.parsed_artifacts is None:
-            self.parsed_artifacts = []
-
-        if self.parsed_storage is None:
-            self.parsed_storage = []
-
-        if self.artifacts_counts is None:
-            self.artifacts_counts = {}
-
-        if self.artifacts_display is None:
-            self.artifacts_display = {}
-
-        if self.preferences is None:
-            self.preferences = []
-
-        if self.origin_hashes is None:
-            self.origin_hashes = {}
 
     @staticmethod
     def format_processing_output(name, items):

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -29,6 +29,7 @@ class WebBrowser(object):
         self.no_copy = no_copy
         self.temp_dir = temp_dir
         self.origin_hashes = {}
+        self.installed_extensions = {}
 
         if self.version is None:
             self.version = []
@@ -135,6 +136,14 @@ class WebBrowser(object):
         domains = self.get_clean_hostnames()
         for domain in domains:
             self.origin_hashes[hashlib.md5(domain.encode()).hexdigest()] = domain
+
+    def get_extension_name_from_id(self, extension_id):
+        if self.installed_extensions and self.installed_extensions.get('data'):
+            for extension in self.installed_extensions['data']:
+                if extension.app_id == extension_id:
+                    return extension.name
+            return "<Extension not found - may have been uninstalled>"
+        return "<Unable to parse installed extensions>"
 
     class HistoryItem(object):
         def __init__(self, item_type, timestamp, profile, url=None, name=None, value=None, interpretation=None):
@@ -376,6 +385,22 @@ class WebBrowser(object):
 
         def __iter__(self):
             return iter(self.__dict__)
+
+    class ExtensionStorageItem(StorageItem):
+        def __init__(self, profile, extension_id, key, value, extension_name=None, seq=None, state=None, source_path=None, offset=None, was_compressed=None):
+            super(WebBrowser.ExtensionStorageItem, self).__init__(
+                item_type='extension storage', profile=profile, origin=extension_id, key=key, value=value, seq=seq, state=state, source_path=source_path
+            )
+            self.profile = profile
+            self.extension_id = extension_id
+            self.extension_name = extension_name
+            self.key = key
+            self.value = value
+            self.seq = seq
+            self.state = state
+            self.source_path = source_path
+            self.offset = offset
+            self.was_compressed = was_compressed
 
     class LocalStorageItem(StorageItem):
         def __init__(self, profile, origin, key, value, seq, state, source_path, last_modified=None):


### PR DESCRIPTION
Add parsing of the following databases related to Extension activity (all use LevelDB and share a similar format):
- Extension Rules
- Extension Scripts
- Extension State
- Local App Settings
- Local Extension Settings
- Managed Extension Settings
- Sync App Settings
- Sync Extension Settings

Added a new class to hold this type of data and a new tab on the XLSX output called `Extension Data` to display it. 

Addresses multiple issues from ["Extensions" milestone](https://github.com/obsidianforensics/hindsight/issues?q=is%3Aissue%20state%3Aopen%20milestone%3AExtensions) (#89, #88, #87, #86, #85, #84).