### PR TITLE
Fix outdated plugin blog post links

### DIFF
--- a/pyhindsight/plugins/google_analytics.py
+++ b/pyhindsight/plugins/google_analytics.py
@@ -4,7 +4,7 @@
 #   Interpret Google Analytics cookies
 #
 # References:
-#   Jon S. Nelson (http://www.dfinews.com/article/google-analytics-cookies-and-forensic-implications)
+#   Jon S. Nelson (https://web.archive.org/web/20140228191123/http://www.dfinews.com/articles/2012/02/google-analytics-cookies-and-forensic-implications)
 #
 # Plugin Author: Ryan Benson (ryan@obsidianforensics.com)
 #

--- a/pyhindsight/plugins/load_balancer_cookies.py
+++ b/pyhindsight/plugins/load_balancer_cookies.py
@@ -6,7 +6,7 @@
 #
 # References:
 #   "Netscaler-Cookie-Decryptor" by Adam Maxwell (https://github.com/catalyst256/Netscaler-Cookie-Decryptor)
-#   "Netscalers: Making sense of the cookie" by Adam Maxwell (https://itgeekchronicles.co.uk/category/netscaler/)
+#   "Netscalers: Making sense of the cookie" by Adam Maxwell (https://web.archive.org/web/20200509063851/https://itgeekchronicles.co.uk/category/netscaler/)
 #   "bigip_cookie_decoder.py" by z0mbiehunt3r (https://github.com/trietptm/loadbalancer-finder/blob/master/
 #      loadbalancer-finder/src/methods/bigip_cookie_decoder.py)
 #

--- a/pyhindsight/plugins/time_discrepancy_finder.py
+++ b/pyhindsight/plugins/time_discrepancy_finder.py
@@ -4,11 +4,11 @@
 #   Attempts to find discrepancies between server-side and local timestamps
 #
 # References:
-#   Lee Whitfield (http://forensic4cast.com/2011/07/flashpost-google-plus-artefacts-url-forwarding/)
-#   Vincent Toubiana and Helen Nissenbaum (http://repository.cmu.edu/cgi/viewcontent.cgi?article=1058&context=jpc)
+#   Lee Whitfield (https://web.archive.org/web/20110712151744/http://forensic4cast.com/2011/07/flashpost-google-plus-artefacts-url-forwarding/)
+#   Vincent Toubiana and Helen Nissenbaum (https://web.archive.org/web/20160308023419/http://repository.cmu.edu/cgi/viewcontent.cgi?article=1058&context=jpc)
 #
 # Blog post explaining plugin:
-#   http://www.obsidianforensics.com/blog/detecting-clock-changes-using-cookies/
+#   https://web.archive.org/web/20131112222848/http://www.obsidianforensics.com/blog/detecting-clock-changes-using-cookies/
 #
 # Plugin Author: Ryan Benson (ryan@obsidianforensics.com)
 #


### PR DESCRIPTION
This addresses https://github.com/obsidianforensics/hindsight/issues/216. I found some other outdated blog post links as well and changed them all to web archive links so that they remain accessible for anyone looking in the future.