### PR TITLE
Refactor cookie parsing and remove unused URLItem fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./pyhindsight/static/h.png" height="100px"/> Hindsight
+<img src="https://raw.githubusercontent.com/RyanDFIR/hindsight/main/pyhindsight/static/h.png" height="100px"/> Hindsight
 =========
 
 Internet history forensics for Google Chrome/Chromium and Mozilla Firefox

--- a/pyhindsight/browsers/chrome.py
+++ b/pyhindsight/browsers/chrome.py
@@ -966,7 +966,10 @@ class Chrome(WebBrowser):
                     base_cookie.url += f' ({base_cookie.top_frame_site_key})'
 
                 base_cookie.source_item = source_item
-                base_cookie.last_update_utc = utils.to_datetime(row.get('last_update_utc'), self.timezone)
+                # Pre-v103 cookie DBs have no last_update_utc column; none_if_unset avoids
+                # logging a parse warning per row and fabricating an epoch-0 timestamp.
+                base_cookie.last_update_utc = utils.to_datetime(
+                    row.get('last_update_utc'), self.timezone, none_if_unset=True)
                 zero_timestamp = utils.to_datetime(0, self.timezone)
 
                 # Create the row for when the cookie was created
@@ -4560,7 +4563,7 @@ class Chrome(WebBrowser):
     def get_transport_security(self, path, dir_name):
         result_list = []
 
-        # Use the URLs from other previously-processed artifacts to generate hashes of domains
+        # Use the URLs from other previously processed artifacts to generate hashes of domains
         # in the form Chrome uses as the 'host' identifier.
         self.build_hsts_domain_hashes()
 
@@ -4582,8 +4585,8 @@ class Chrome(WebBrowser):
             ts_json = json.loads(f.read())
 
             # As of now (2021), there are two versions of the TransportSecurity JSON file.
-            # Version 2 has a top level "version" key (with a value of 2), and version 1
-            # has the HSTS domain hashes as top level keys.
+            # Version 2 has a top-level "version" key (with a value of 2), and version 1
+            # has the HSTS domain hashes as top-level keys.
 
             # Version 2
             if ts_json.get('version'):

--- a/pyhindsight/browsers/webbrowser.py
+++ b/pyhindsight/browsers/webbrowser.py
@@ -318,7 +318,7 @@ class WebBrowser(object):
                 self, profile, visit_id, url, title, visit_time, last_visit_time, visit_count, typed_count, from_visit,
                 transition, hidden, favicon_id, indexed=None, visit_duration=None, visit_source=None,
                 transition_friendly=None, is_known_to_sync=None, originator_cache_guid=None, opener_visit=None,
-                category_ids=None, entity_ids=None, cluster_id=None, cluster_label=None,
+                category_ids=None, entity_ids=None,
                 response_code=None, tab_id=None, window_id=None):
             super(WebBrowser.URLItem, self).__init__('url', timestamp=visit_time, profile=profile, url=url, name=title)
             self.profile = profile
@@ -342,13 +342,9 @@ class WebBrowser(object):
             self.opener_visit = opener_visit
             self.category_ids = category_ids
             self.entity_ids = entity_ids
-            self.category_names = None
-            self.entity_names = None
             self.categories_str = None
             self.entities_str = None
             self.cluster_str = None
-            self.cluster_id = cluster_id
-            self.cluster_label = cluster_label
             self.response_code = response_code
             self.tab_id = tab_id
             self.window_id = window_id


### PR DESCRIPTION
- Handle `last_update_utc` appropriately for pre-v103 Chrome cookie databases to avoid warnings and fabricated timestamps.
- Fix grammar in comments related to TransportSecurity JSON parsing.
- Update image URL in README to use raw GitHub link.
- Remove unused `cluster_id` and `cluster_label` fields from `URLItem`.