### PR TITLE
Fix KeyError on cookies with no expires_utc (e.g. Firefox session cookies)

### DIFF
--- a/pyhindsight/analysis.py
+++ b/pyhindsight/analysis.py
@@ -72,7 +72,7 @@ class HindsightEncoder(json.JSONEncoder):
             item['timestamp_desc'] = 'Last Visited Time'
             item['data_type'] = 'chrome:history:page_visited'
             item['url_hidden'] = 'true' if item['hidden'] else 'false'
-            if item['visit_duration'] == 'None':
+            if item.get('visit_duration') == 'None':
                 del (item['visit_duration'])
 
             item['message'] = f"{item['url']} ({item['title']}) [count: {item['visit_count']}]"
@@ -213,7 +213,7 @@ class HindsightEncoder(json.JSONEncoder):
             item['data'] = item['value'] if item['value'] != '<encrypted>' else ''
             item['url'] = item['url'].lstrip('.')
             item['url'] = f'https://{item["url"]}' if item['secure'] else f'http://{item["url"]}'
-            if item['expires_utc'] == '1970-01-01T00:00:00+00:00':
+            if item.get('expires_utc') == '1970-01-01T00:00:00+00:00':
                 del(item['expires_utc'])
             # Convert these from 1/0 to true/false to match Plaso
             item['secure'] = 'true' if item['secure'] else 'false'


### PR DESCRIPTION
## Problem

`HindsightEncoder.default()` crashes with `KeyError: 'expires_utc'` when
serializing a cookie item whose `expires_utc` is `None`  which happens
for session cookies (no expiration set). This reliably reproduces when
processing a Firefox profile with any session cookies present.

Traceback:

    File "pyhindsight/analysis.py", line 2967, in generate_jsonl
    File "pyhindsight/analysis.py", line 2959, in write_jsonl_record
    File "json/encoder.py", line 263, in iterencode
    File "pyhindsight/analysis.py", line 216, in default
    KeyError: 'expires_utc'

## Root cause

`base_encoder()` drops any field whose value is `None` (analysis.py,
line ~42). Firefox's session-cookie handling (browsers/firefox.py,
~line 387) sets `expires_utc=None` when a cookie has no expiry. By the
time `default()` reaches the cookie branch and does `item['expires_utc']`,
that key has already been silently dropped, causing the KeyError.

I also found the identical pattern a few lines earlier
(`item['visit_duration']`, line 75)  same risk, not yet triggered but
same shape, so I fixed it defensively too.

## Fix

Two one-line changes, using `.get()` instead of direct indexing so a
missing (dropped) key just evaluates the comparison as False instead of
raising:

    -            if item['visit_duration'] == 'None':
    +            if item.get('visit_duration') == 'None':

    -            if item['expires_utc'] == '1970-01-01T00:00:00+00:00':
    +            if item.get('expires_utc') == '1970-01-01T00:00:00+00:00':

## Testing

Verified against a real Firefox profile with session cookies (previously
crashed 100% of the time on `-f jsonl` output)  now completes cleanly
and writes all cookie records to the JSONL output, including the
session cookies that previously caused the crash.